### PR TITLE
feat: initial TUI layout support with Cassowary

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,8 @@
+import BackBreeze.IExHelpers
+
+alias BackBreeze.Layout
+alias BackBreeze.Layout.Constraint
+alias BackBreeze.Layout.Element
+alias BackBreeze.Rect
+
+alias Cassowary.Solver

--- a/lib/back_breeze.ex
+++ b/lib/back_breeze.ex
@@ -7,14 +7,18 @@ defmodule BackBreeze do
   Return the screen dimensions. Use the terminal dimensions if specified
   otherwise calculate using the `:io` module.
   """
+  @spec screen_dimensions(struct() | nil) :: {non_neg_integer(), non_neg_integer()}
+  def screen_dimensions(terminal \\ nil)
   def screen_dimensions(%Termite.Terminal{size: size}), do: {size.width, size.height}
   def screen_dimensions(nil), do: {screen_width(), screen_height()}
 
+  @spec screen_width() :: non_neg_integer()
   defp screen_width() do
     {:ok, cols} = :io.columns()
     cols
   end
 
+  @spec screen_height() :: non_neg_integer()
   defp screen_height() do
     {:ok, height} = :io.rows()
     height

--- a/lib/back_breeze/application.ex
+++ b/lib/back_breeze/application.ex
@@ -1,0 +1,11 @@
+defmodule BackBreeze.Application do
+  @doc false
+
+  use Application
+
+  def start(_type, _args) do
+    children = [Cassowary.Variable.ID]
+
+    Supervisor.start_link(children, strategy: :one_for_one)
+  end
+end

--- a/lib/back_breeze/iex_helper.ex
+++ b/lib/back_breeze/iex_helper.ex
@@ -1,0 +1,6 @@
+defmodule BackBreeze.IExHelpers do
+  import IEx.Helpers
+
+  def r, do: recompile()
+  def rf, do: recompile(force: true)
+end

--- a/lib/back_breeze/layout.ex
+++ b/lib/back_breeze/layout.ex
@@ -1,0 +1,611 @@
+defmodule BackBreeze.Layout do
+  @type direction :: :horizontal | :vertical
+  @type flex :: :start | :center | :end | :space_between | :space_around | :space_evenly
+  @type t :: %__MODULE__{
+          direction: direction(),
+          constraints: [BackBreeze.Layout.Constraint.t()],
+          margin: BackBreeze.Layout.Margin.t(),
+          flex: flex(),
+          spacing: BackBreeze.Layout.Spacing.t()
+        }
+
+  defstruct constraints: [],
+            direction: :vertical,
+            margin: %BackBreeze.Layout.Margin{},
+            flex: :start,
+            spacing: %BackBreeze.Layout.Spacing{}
+
+  alias Cassowary.Expression
+  alias BackBreeze.Layout.Constraint
+  alias BackBreeze.Layout
+  alias BackBreeze.Layout.{Element, Margin, Spacing, Constants}
+  alias BackBreeze.Rect
+  alias Cassowary.{Solver, Variable}
+
+  def new(direction, constraints, margin, flex) do
+    %Layout{
+      direction: direction,
+      constraints: constraints,
+      margin: margin,
+      flex: flex
+    }
+  end
+
+  def vertical() do
+    %Layout{}
+  end
+
+  def horizontal() do
+    %Layout{direction: :horizontal}
+  end
+
+  def constraints(%Layout{} = layout, constraints) do
+    %{layout | constraints: constraints}
+  end
+
+  def direction(%Layout{} = layout, direction) do
+    %{layout | direction: direction}
+  end
+
+  def margin(%Layout{} = layout, %Margin{} = margin) do
+    %{layout | margin: margin}
+  end
+
+  def margin(%Layout{} = layout, margin) when is_integer(margin) and margin >= 0 do
+    %{layout | margin: Margin.new(margin, margin)}
+  end
+
+  def margin(%Layout{} = layout, {h, v})
+      when is_integer(h) and h >= 0 and is_integer(v) and v >= 0 do
+    %{layout | margin: Margin.new(h, v)}
+  end
+
+  def flex(%Layout{} = layout, flex) do
+    %{layout | flex: flex}
+  end
+
+  def spacing(%Layout{} = layout, %Spacing{} = spacing) do
+    %{layout | spacing: spacing}
+  end
+
+  def spacing(%Layout{} = layout, spacing) when is_integer(spacing) do
+    spacing =
+      if spacing < 0 do
+        Spacing.new(:overlap, abs(spacing))
+      else
+        Spacing.new(:space, abs(spacing))
+      end
+
+    %{layout | spacing: spacing}
+  end
+
+  @spec split(%Layout{}, Rect.t()) :: [Element.t()]
+  def split(%Layout{constraints: []}, _rect) do
+    []
+  end
+
+  def split(%Layout{} = layout, area) do
+    layout
+    |> do_split(area)
+    |> elem(0)
+  end
+
+  @spec do_split(%Layout{}, Rect.t()) :: [Element.t()]
+  defp do_split(layout, area) do
+    solver = Solver.new()
+    inner_area = Rect.inner(area, layout.margin)
+
+    {area_start, area_end} =
+      case layout.direction do
+        :horizontal ->
+          {inner_area.x * Constants.float_precision_multiplier(),
+           Rect.right(inner_area) * Constants.float_precision_multiplier()}
+
+        :vertical ->
+          {inner_area.y * Constants.float_precision_multiplier(),
+           Rect.bottom(inner_area) * Constants.float_precision_multiplier()}
+      end
+
+    variable_count = length(layout.constraints) * 2 + 2
+
+    variables =
+      Enum.map(1..variable_count, fn _ ->
+        Variable.new()
+      end)
+
+    spacers =
+      variables
+      |> Enum.chunk_every(2)
+      |> Enum.map(fn [a, b] ->
+        Layout.Element.new(a, b)
+      end)
+
+    segments =
+      variables
+      |> Enum.drop(1)
+      |> Enum.chunk_every(2, 2, :discard)
+      |> Enum.map(fn [a, b] ->
+        Layout.Element.new(a, b)
+      end)
+
+    flex = layout.flex
+
+    spacing =
+      case layout.spacing.type do
+        :space -> layout.spacing.value
+        :overlap -> -layout.spacing.value
+      end
+
+    constraints = layout.constraints
+    area_size = Element.new(List.first(variables), List.last(variables))
+
+    with {:ok, solver} <- configure_area(solver, area_size, area_start, area_end),
+         {:ok, solver} <- configure_variable_in_area_constraints(solver, variables, area_size),
+         {:ok, solver} <- configure_variable_constraints(solver, variables),
+         {:ok, solver} <-
+           configure_flex_constraints(solver, area_size, spacers, flex, spacing),
+         {:ok, solver} <- configure_constraints(solver, area_size, segments, constraints),
+         {:ok, solver} <- configure_fill_constraints(solver, segments, constraints),
+         {:ok, solver} =
+           segments
+           |> Enum.chunk_every(2, 1, :discard)
+           |> Enum.reduce({:ok, solver}, fn
+             [left, right], {:ok, solver} ->
+               Solver.add_constraint(
+                 solver,
+                 Element.has_size(left, right, Constants.all_segment_grow())
+               )
+
+             [_left, _right], {:error, reason} ->
+               {:error, reason}
+           end) do
+      solver = Solver.fetch_changes(solver)
+      changes = Enum.into(solver.public_changes, %{})
+
+      segment_rects =
+        changes_to_rects(changes, segments, inner_area, layout.direction)
+
+      spacer_rects =
+        changes_to_rects(changes, spacers, inner_area, layout.direction)
+
+      {segment_rects, spacer_rects}
+    end
+  end
+
+  @spec configure_area(Solver.t(), Element.t(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, Solver.t()} | {:error, atom()}
+  defp configure_area(solver, area, area_start, area_end) do
+    with {:ok, solver} <-
+           Solver.add_constraint(solver, Cassowary.Constraint.eq(area.start, area_start)),
+         {:ok, solver} <-
+           Solver.add_constraint(solver, Cassowary.Constraint.eq(area.end, area_end)) do
+      {:ok, solver}
+    end
+  end
+
+  @spec configure_variable_in_area_constraints(Solver.t(), [Variable.t()], Element.t()) ::
+          {:ok, Solver.t()} | {:error, atom()}
+  defp configure_variable_in_area_constraints(solver, variables, area) do
+    variables
+    |> Enum.slice(1..-2//1)
+    |> Enum.reduce({:ok, solver}, fn
+      variable, {:ok, solver} ->
+        constraint = Cassowary.Constraint.ge(variable, area.start)
+
+        with {:ok, solver} <- Solver.add_constraint(solver, constraint),
+             constraint = Cassowary.Constraint.le(variable, area.end),
+             {:ok, solver} <- Solver.add_constraint(solver, constraint) do
+          {:ok, solver}
+        end
+
+      _variable, {:error, reason} ->
+        {:error, reason}
+    end)
+  end
+
+  @spec configure_variable_constraints(Solver.t(), [Variable.t()]) ::
+          {:ok, Solver.t()} | {:error, atom()}
+  defp configure_variable_constraints(solver, variables) do
+    variables
+    |> Enum.slice(1..-2//1)
+    |> Enum.chunk_every(2, 1, :discard)
+    |> Enum.reduce({:ok, solver}, fn
+      [left, right], {:ok, solver} ->
+        Solver.add_constraint(solver, Cassowary.Constraint.le(left, right))
+
+      [_left, _right], {:error, reason} ->
+        {:error, reason}
+    end)
+  end
+
+  @spec configure_flex_constraints(Solver.t(), Rect.t(), [Element.t()], flex(), number()) ::
+          {:ok, Solver.t()} | {:error, atom()}
+  defp configure_flex_constraints(solver, area, spacers, flex, spacing) do
+    spacers_except_first_and_last = Enum.slice(spacers, 1..-2//1)
+    spacing = spacing * Constants.float_precision_multiplier()
+
+    case flex do
+      :start ->
+        {:ok, solver} =
+          Enum.reduce(spacers_except_first_and_last, {:ok, solver}, fn
+            spacer, {:ok, solver} ->
+              Solver.add_constraint(
+                solver,
+                Element.has_size(spacer, spacing, Constants.spacer_size_eq())
+              )
+
+            _spacer, {:error, reason} ->
+              {:error, reason}
+          end)
+
+        first = List.first(spacers)
+        last = List.last(spacers)
+
+        with {:ok, solver} <- Solver.add_constraint(solver, Element.is_empty(first)),
+             {:ok, solver} <-
+               Solver.add_constraint(solver, Element.has_size(last, area, Constants.grow())) do
+          {:ok, solver}
+        end
+
+      :center ->
+        first = List.first(spacers)
+        last = List.last(spacers)
+
+        with {:ok, solver} <-
+               Enum.reduce(spacers_except_first_and_last, {:ok, solver}, fn
+                 spacer, {:ok, solver} ->
+                   Solver.add_constraint(
+                     solver,
+                     Element.has_size(spacer, spacing, Constants.spacer_size_eq())
+                   )
+
+                 _spacer, {:error, reason} ->
+                   {:error, reason}
+               end),
+             {:ok, solver} <-
+               Solver.add_constraint(solver, Element.has_size(first, area, Constants.grow())),
+             {:ok, solver} <-
+               Solver.add_constraint(solver, Element.has_size(last, area, Constants.grow())),
+             {:ok, solver} <-
+               Solver.add_constraint(
+                 solver,
+                 Element.has_size(first, last, Constants.spacer_size_eq())
+               ) do
+          {:ok, solver}
+        end
+
+      :end ->
+        {:ok, solver} =
+          Enum.reduce(spacers_except_first_and_last, {:ok, solver}, fn
+            spacer, {:ok, solver} ->
+              Solver.add_constraint(
+                solver,
+                Element.has_size(spacer, spacing, Constants.spacer_size_eq())
+              )
+
+            _spacer, {:error, reason} ->
+              {:error, reason}
+          end)
+
+        with {:ok, solver} <-
+               Solver.add_constraint(solver, Element.is_empty(List.last(spacers))),
+             {:ok, solver} <-
+               Solver.add_constraint(
+                 solver,
+                 Element.has_size(List.first(spacers), area, Constants.grow())
+               ) do
+          {:ok, solver}
+        end
+
+      :space_between ->
+        with {:ok, solver} <-
+               Enum.reduce(spacers_except_first_and_last, {:ok, solver}, fn
+                 spacer, {:ok, solver} ->
+                   Solver.add_constraint(
+                     solver,
+                     Element.has_size(spacer, spacing, Constants.spacer_size_eq())
+                   )
+
+                 _spacer, {:error, reason} ->
+                   {:error, reason}
+               end),
+             {:ok, solver} <-
+               spacers_except_first_and_last
+               |> tuple_combinations()
+               |> Enum.reduce({:ok, solver}, fn
+                 {left, right}, {:ok, solver} ->
+                   Solver.add_constraint(
+                     solver,
+                     Element.has_size(left, right, Constants.spacer_size_eq())
+                   )
+
+                 {_left, _right}, {:error, reason} ->
+                   {:error, reason}
+               end),
+             {:ok, solver} <-
+               Enum.reduce(spacers_except_first_and_last, {:ok, solver}, fn
+                 spacer, {:ok, solver} ->
+                   {:ok, solver} =
+                     Solver.add_constraint(
+                       solver,
+                       Element.has_min_size(spacer, spacing, Constants.spacer_size_eq())
+                     )
+
+                   Solver.add_constraint(
+                     solver,
+                     Element.has_size(spacer, area, Constants.space_grow())
+                   )
+
+                 _spacer, {:error, reason} ->
+                   {:error, reason}
+               end),
+             first = List.first(spacers),
+             last = List.last(spacers),
+             {:ok, solver} <- Solver.add_constraint(solver, Element.is_empty(first)),
+             {:ok, solver} <- Solver.add_constraint(solver, Element.is_empty(last)) do
+          {:ok, solver}
+        end
+
+      :space_around ->
+        if length(spacers) <= 2 do
+          {:ok, solver} =
+            spacers
+            |> tuple_combinations()
+            |> Enum.reduce({:ok, solver}, fn
+              {left, right}, {:ok, solver} ->
+                Solver.add_constraint(
+                  solver,
+                  Element.has_size(left, right, Constants.spacer_size_eq())
+                )
+
+              {_left, _right}, {:error, reason} ->
+                {:error, reason}
+            end)
+
+          Enum.reduce(spacers, {:ok, solver}, fn
+            spacer, {:ok, solver} ->
+              {:ok, solver} =
+                Solver.add_constraint(
+                  solver,
+                  Element.has_min_size(spacer, spacing, Constants.spacer_size_eq())
+                )
+
+              Solver.add_constraint(
+                solver,
+                Element.has_size(spacer, area, Constants.space_grow())
+              )
+
+            _spacer, {:error, reason} ->
+              {:error, reason}
+          end)
+        else
+          [first | rest] = spacers
+          {last, middle} = {List.last(rest), Enum.slice(rest, 0..-2//1)}
+          first_middle = List.first(middle)
+
+          with {:ok, solver} <-
+                 middle
+                 |> tuple_combinations()
+                 |> Enum.reduce({:ok, solver}, fn
+                   {left, right}, {:ok, solver} ->
+                     Solver.add_constraint(
+                       solver,
+                       Element.has_size(left, right, Constants.spacer_size_eq())
+                     )
+
+                   {_left, _right}, {:error, reason} ->
+                     {:error, reason}
+                 end),
+               {:ok, solver} <-
+                 Solver.add_constraint(
+                   solver,
+                   Element.has_double_size(first_middle, first, Constants.spacer_size_eq())
+                 ),
+               {:ok, solver} <-
+                 Solver.add_constraint(
+                   solver,
+                   Element.has_double_size(first_middle, last, Constants.spacer_size_eq())
+                 ),
+               {:ok, solver} <-
+                 Enum.reduce(spacers, {:ok, solver}, fn
+                   spacer, {:ok, solver} ->
+                     with {:ok, solver} <-
+                            Solver.add_constraint(
+                              solver,
+                              Element.has_min_size(spacer, spacing, Constants.spacer_size_eq())
+                            ),
+                          {:ok, solver} <-
+                            Solver.add_constraint(
+                              solver,
+                              Element.has_size(spacer, area, Constants.space_grow())
+                            ) do
+                       {:ok, solver}
+                     end
+
+                   _spacer, {:error, reason} ->
+                     {:error, reason}
+                 end) do
+            {:ok, solver}
+          end
+        end
+
+      :space_evenly ->
+        {:ok, solver} =
+          spacers
+          |> tuple_combinations()
+          |> Enum.reduce({:ok, solver}, fn
+            {left, right}, {:ok, solver} ->
+              Solver.add_constraint(
+                solver,
+                Element.has_size(left, right, Constants.spacer_size_eq())
+              )
+
+            {_left, _right}, {:error, reason} ->
+              {:error, reason}
+          end)
+
+        Enum.reduce(spacers, {:ok, solver}, fn
+          spacer, {:ok, solver} ->
+            with {:ok, solver} <-
+                   Solver.add_constraint(
+                     solver,
+                     Element.has_min_size(spacer, spacing, Constants.spacer_size_eq())
+                   ),
+                 {:ok, solver} <-
+                   Solver.add_constraint(
+                     solver,
+                     Element.has_size(spacer, area, Constants.space_grow())
+                   ) do
+              {:ok, solver}
+            end
+
+          _spacer, {:error, reason} ->
+            {:error, reason}
+        end)
+    end
+  end
+
+  @spec configure_constraints(t(), Rect.t(), [Element.t()], [Constraint.t()]) ::
+          {:ok, t()} | {:error, String.t()}
+  defp configure_constraints(solver, area, segments, constraints) do
+    constraints
+    |> Enum.zip(segments)
+    |> Enum.reduce({:ok, solver}, fn
+      {constraint, segment}, {:ok, solver} ->
+        case constraint do
+          %Constraint{type: :max, value: max} ->
+            with {:ok, solver} <-
+                   Solver.add_constraint(
+                     solver,
+                     Element.has_max_size(segment, max, Constants.max_size_le())
+                   ),
+                 {:ok, solver} <-
+                   Solver.add_constraint(
+                     solver,
+                     Element.has_int_size(segment, max, Constants.max_size_eq())
+                   ) do
+              {:ok, solver}
+            end
+
+          %Constraint{type: :min, value: min} ->
+            with {:ok, solver} <-
+                   Solver.add_constraint(
+                     solver,
+                     Element.has_min_size(segment, min, Constants.min_size_ge())
+                   ),
+                 {:ok, solver} <-
+                   Solver.add_constraint(
+                     solver,
+                     Element.has_size(segment, area, Constants.fill_grow())
+                   ) do
+              {:ok, solver}
+            end
+
+          %Constraint{type: :length, value: length} ->
+            constraint = Element.has_int_size(segment, length, Constants.length_size_eq())
+
+            Solver.add_constraint(solver, constraint)
+
+          %Constraint{type: :percentage, value: p} ->
+            size =
+              area
+              |> Element.size()
+              |> Expression.multiply(p)
+              |> Expression.divide(100)
+
+            Solver.add_constraint(
+              solver,
+              Element.has_size(segment, size, Constants.percentage_size_eq())
+            )
+
+          %Constraint{type: :ratio, value: {num, den}} ->
+            size =
+              Element.size(area)
+              |> Expression.multiply(num)
+              |> Expression.divide(max(den, 1))
+
+            Solver.add_constraint(
+              solver,
+              Element.has_size(segment, size, Constants.ratio_size_eq())
+            )
+
+          %Constraint{type: :fill} ->
+            Solver.add_constraint(
+              solver,
+              Element.has_size(segment, area, Constants.fill_grow())
+            )
+        end
+
+      {_constraint, _segment}, {:error, reason} ->
+        {:error, reason}
+    end)
+  end
+
+  defp configure_fill_constraints(solver, segments, constraints) do
+    constraints
+    |> Enum.zip(segments)
+    |> Enum.filter(fn {c, _} -> c.type in [:fill, :min] end)
+    |> tuple_combinations()
+    |> Enum.reduce({:ok, solver}, fn
+      {{left_constraint, left_segment}, {right_constraint, right_segment}}, {:ok, solver} ->
+        left_scaling_factor =
+          case left_constraint do
+            %Constraint{type: :fill, value: scale} -> max(scale, 1.0e-6)
+            %Constraint{type: :min} -> 1.0
+          end
+
+        right_scaling_factor =
+          case right_constraint do
+            %Constraint{type: :fill, value: scale} -> max(scale, 1.0e-6)
+            %Constraint{type: :min} -> 1.0
+          end
+
+        left =
+          left_segment
+          |> Element.size()
+          |> Expression.multiply(right_scaling_factor)
+
+        right =
+          right_segment
+          |> Element.size()
+          |> Expression.multiply(left_scaling_factor)
+
+        Solver.add_constraint(
+          solver,
+          Cassowary.Constraint.eq(left, right, Constants.grow())
+        )
+
+      {{_left_constraint, _left_segment}, {_right_constraint, _right_segment}},
+      {:error, reason} ->
+        {:error, reason}
+    end)
+  end
+
+  @spec tuple_combinations([any()]) :: [{any(), any()}]
+  def tuple_combinations(enum) do
+    for {left, i} <- Enum.with_index(enum),
+        {right, j} <- Enum.with_index(enum),
+        i < j do
+      {left, right}
+    end
+  end
+
+  @spec changes_to_rects(map(), [Element.t()], Rect.t(), :horizontal | :vertical) :: [Rect.t()]
+  defp changes_to_rects(changes, elements, area, direction) do
+    Enum.map(elements, fn element ->
+      start_value = Map.get(changes, element.start, 0.0)
+      end_value = Map.get(changes, element.end, 0.0)
+      start_value = round(round(start_value) / Constants.float_precision_multiplier())
+      end_value = round(round(end_value) / Constants.float_precision_multiplier())
+      size = end_value - start_value
+
+      case direction do
+        :horizontal ->
+          Rect.new(start_value, area.y, size, area.height)
+
+        :vertical ->
+          Rect.new(area.x, start_value, area.width, size)
+      end
+    end)
+  end
+end

--- a/lib/back_breeze/layout/constants.ex
+++ b/lib/back_breeze/layout/constants.ex
@@ -1,0 +1,42 @@
+defmodule BackBreeze.Layout.Constants do
+  alias Cassowary.Strength
+
+  @float_precision_multiplier 100.0
+  def float_precision_multiplier, do: @float_precision_multiplier
+
+  @spacer_size_eq Strength.required() / 10.0
+  def spacer_size_eq, do: @spacer_size_eq
+
+  @grow Strength.medium() / 10.0
+  def grow, do: @grow
+
+  @space_grow Strength.weak() * 10.0
+  def space_grow, do: @space_grow
+
+  @max_size_le Strength.strong() * 100.0
+  def max_size_le, do: @max_size_le
+
+  @max_size_eq Strength.medium() * 10.0
+  def max_size_eq, do: @max_size_eq
+
+  @fill_grow Strength.medium()
+  def fill_grow, do: @fill_grow
+
+  @min_size_eq Strength.medium() * 10.0
+  def min_size_eq, do: @min_size_eq
+
+  @min_size_ge Strength.strong() * 100.0
+  def min_size_ge, do: @min_size_ge
+
+  @length_size_eq Strength.strong() * 10.0
+  def length_size_eq, do: @length_size_eq
+
+  @percentage_size_eq Strength.strong()
+  def percentage_size_eq, do: @percentage_size_eq
+
+  @ratio_size_eq Strength.strong() / 10.0
+  def ratio_size_eq, do: @ratio_size_eq
+
+  @all_segment_grow Strength.weak()
+  def all_segment_grow, do: @all_segment_grow
+end

--- a/lib/back_breeze/layout/constraint.ex
+++ b/lib/back_breeze/layout/constraint.ex
@@ -1,0 +1,57 @@
+defmodule BackBreeze.Layout.Constraint do
+  alias __MODULE__
+
+  @type type :: :min | :max | :length | :percentage | :fill | :ratio
+  @type ratio_t() :: %Constraint{
+          type: :ratio,
+          value: {non_neg_integer(), non_neg_integer()}
+        }
+  @type t ::
+          %Constraint{
+            type: :min | :max | :length | :percentage | :fill,
+            value: non_neg_integer()
+          }
+          | ratio_t()
+
+  defstruct [:type, :value]
+
+  @types [:min, :max, :length, :percentage, :ratio, :fill]
+
+  @spec new(type(), non_neg_integer() | {non_neg_integer(), non_neg_integer()}) :: t()
+  def new(type, value)
+      when (type in @types and (is_number(value) and value >= 0)) or
+             (is_tuple(value) and tuple_size(value) == 2) do
+    %Constraint{type: type, value: value}
+  end
+
+  @spec min(non_neg_integer()) :: t()
+  def min(value) when is_number(value) and value >= 0 do
+    new(:min, value)
+  end
+
+  @spec max(non_neg_integer()) :: t()
+  def max(value) when is_number(value) and value >= 0 do
+    new(:max, value)
+  end
+
+  @spec length(non_neg_integer()) :: t()
+  def length(value) when is_number(value) and value >= 0 do
+    new(:length, value)
+  end
+
+  @spec percentage(non_neg_integer()) :: t()
+  def percentage(value) when is_number(value) and value >= 0 and value <= 100 do
+    new(:percentage, value)
+  end
+
+  @spec ratio({non_neg_integer(), non_neg_integer()}) :: t()
+  def ratio({num, den})
+      when is_number(num) and num >= 0 and is_number(den) and den >= 0 do
+    new(:ratio, {num, den})
+  end
+
+  @spec fill(non_neg_integer()) :: t()
+  def fill(value) when is_number(value) and value >= 0 do
+    new(:fill, value)
+  end
+end

--- a/lib/back_breeze/layout/element.ex
+++ b/lib/back_breeze/layout/element.ex
@@ -1,0 +1,64 @@
+defmodule BackBreeze.Layout.Element do
+  alias __MODULE__
+  alias BackBreeze.Layout.Constants
+  alias Cassowary.{Variable, Expression, Strength, Constraint}
+
+  @type t() :: %Element{start: Variable.t(), end: Variable.t()}
+
+  defstruct [:start, :end]
+
+  def new(%Variable{} = start_var, %Variable{} = end_var) do
+    %Element{start: start_var, end: end_var}
+  end
+
+  @spec size(t()) :: Expression.t()
+  def size(%Element{} = element) do
+    Expression.subtract(element.end, element.start)
+  end
+
+  @spec has_size(t(), float() | t() | Expression.t(), Strength.t()) :: Constraint.t()
+  def has_size(%Element{} = element, %Element{} = size, strength) do
+    expr = size(size)
+
+    element
+    |> size()
+    |> Constraint.eq(expr, strength)
+  end
+
+  def has_size(%Element{} = element, size, strength) do
+    element
+    |> size()
+    |> Constraint.eq(size, strength)
+  end
+
+  def has_min_size(%Element{} = element, size, strength) when is_number(size) do
+    element
+    |> size()
+    |> Constraint.ge(size * Constants.float_precision_multiplier(), strength)
+  end
+
+  def has_double_size(%Element{} = element, %Element{} = size, strength) do
+    element
+    |> size()
+    |> Constraint.eq(size |> size() |> Expression.multiply(2), strength)
+  end
+
+  def has_max_size(%Element{} = element, size, strength) when is_integer(size) do
+    element
+    |> size()
+    |> Constraint.le(size * Constants.float_precision_multiplier(), strength)
+  end
+
+  @spec has_int_size(t(), non_neg_integer(), Strength.t()) :: Constraint.t()
+  def has_int_size(%Element{} = element, size, strength) when is_integer(size) do
+    element
+    |> size()
+    |> Constraint.eq(size * Constants.float_precision_multiplier(), strength)
+  end
+
+  def is_empty(%Element{} = element) do
+    element
+    |> size()
+    |> Constraint.eq(0.0, Strength.required() - Strength.weak())
+  end
+end

--- a/lib/back_breeze/layout/margin.ex
+++ b/lib/back_breeze/layout/margin.ex
@@ -1,0 +1,12 @@
+defmodule BackBreeze.Layout.Margin do
+  @type t :: %__MODULE__{horizontal: non_neg_integer(), vertical: non_neg_integer()}
+
+  defstruct horizontal: 0, vertical: 0
+
+  alias __MODULE__
+
+  @spec new(non_neg_integer(), non_neg_integer()) :: t()
+  def new(horizontal, vertical) do
+    %Margin{horizontal: horizontal, vertical: vertical}
+  end
+end

--- a/lib/back_breeze/layout/spacing.ex
+++ b/lib/back_breeze/layout/spacing.ex
@@ -1,0 +1,13 @@
+defmodule BackBreeze.Layout.Spacing do
+  @type type :: :space | :overlap
+  @type t :: %__MODULE__{type: type(), value: non_neg_integer()}
+
+  defstruct type: :space, value: 0
+
+  alias __MODULE__
+
+  @spec new(type(), non_neg_integer()) :: t()
+  def new(type, value) when is_integer(value) and value >= 0 do
+    %Spacing{type: type, value: value}
+  end
+end

--- a/lib/back_breeze/rect.ex
+++ b/lib/back_breeze/rect.ex
@@ -1,0 +1,57 @@
+defmodule BackBreeze.Rect do
+  alias __MODULE__
+  alias BackBreeze.Layout.Margin
+
+  @type t :: %Rect{
+          x: non_neg_integer(),
+          y: non_neg_integer(),
+          width: non_neg_integer(),
+          height: non_neg_integer()
+        }
+
+  defstruct x: 0, y: 0, width: 0, height: 0
+
+  @spec new(non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()) :: t()
+  def new(x, y, width, height)
+      when is_integer(x) and is_integer(y) and is_integer(width) and is_integer(height) do
+    %Rect{width: width, height: height, x: x, y: y}
+  end
+
+  @spec fullscreen() :: t()
+  def fullscreen do
+    {width, height} = BackBreeze.screen_dimensions()
+
+    new(0, 0, width, height)
+  end
+
+  @spec inner(t(), Margin.t()) :: t()
+  def inner(%Rect{} = rect, %Margin{} = margin) do
+    %{horizontal: horizontal, vertical: vertical} = margin
+
+    rect
+    |> Map.put(:x, rect.x + horizontal)
+    |> Map.put(:y, rect.y + vertical)
+    |> Map.put(:width, rect.width - horizontal * 2)
+    |> Map.put(:height, rect.height - vertical * 2)
+  end
+
+  @spec left(t()) :: non_neg_integer()
+  def left(%Rect{x: x}) do
+    x
+  end
+
+  @spec right(t()) :: non_neg_integer()
+  def right(%Rect{x: x, width: width}) do
+    x + width
+  end
+
+  @spec top(t()) :: non_neg_integer()
+  def top(%Rect{y: y}) do
+    y
+  end
+
+  @spec bottom(t()) :: non_neg_integer()
+  def bottom(%Rect{y: y, height: height}) do
+    y + height
+  end
+end

--- a/lib/cassowary.ex
+++ b/lib/cassowary.ex
@@ -1,0 +1,2 @@
+defmodule Cassowary do
+end

--- a/lib/cassowary/constraint.ex
+++ b/lib/cassowary/constraint.ex
@@ -1,0 +1,56 @@
+defmodule Cassowary.Constraint do
+  alias __MODULE__
+  alias Cassowary.{Expression, Strength, Variable}
+
+  @type operators() :: :== | :>= | :<=
+  @type t() :: %__MODULE__{
+          expression: Expression.t(),
+          operator: operators(),
+          strength: float()
+        }
+
+  import Strength, only: [is_strength: 1]
+
+  @enforce_keys [:expression, :operator, :strength]
+  defstruct [:expression, :operator, :strength]
+
+  @eq :==
+  @ge :>=
+  @le :<=
+
+  @operators [@eq, @ge, @le]
+
+  @spec new(%Expression{}, operators(), float()) :: t()
+  def new(%Expression{} = expression, operator, strength \\ Strength.required())
+      when operator in @operators and is_strength(strength) do
+    %__MODULE__{expression: expression, operator: operator, strength: strength}
+  end
+
+  @spec eq(%Expression{}, %Expression{} | %Variable{} | number(), float()) :: t()
+  def eq(lhs, rhs, strength \\ Strength.required()) do
+    lhs
+    |> Expression.subtract(rhs)
+    |> new(@eq, strength)
+  end
+
+  @spec le(%Expression{}, %Expression{} | %Variable{} | number(), float()) :: t()
+  def le(lhs, rhs, strength \\ Strength.required()) do
+    lhs
+    |> Expression.subtract(rhs)
+    |> new(@le, strength)
+  end
+
+  @spec ge(%Expression{}, %Expression{} | %Variable{} | number(), float()) :: t()
+  def ge(lhs, rhs, strength \\ Strength.required()) do
+    lhs
+    |> Expression.subtract(rhs)
+    |> new(@ge, strength)
+  end
+
+  def pretty_print(%Constraint{} = constraint) do
+    constraint.expression
+    |> Expression.pretty_print()
+    |> List.insert_at(-2, constraint.operator)
+    |> Enum.join(" ")
+  end
+end

--- a/lib/cassowary/expression.ex
+++ b/lib/cassowary/expression.ex
@@ -1,0 +1,66 @@
+defmodule Cassowary.Expression do
+  alias __MODULE__
+  alias Cassowary.{Term, Variable}
+
+  @type t() :: %Expression{terms: [Term.t()], constant: float()}
+
+  defstruct terms: [], constant: 0.0
+
+  @spec new(Term.t() | [Term.t()], float()) :: t()
+  def new(term, constant \\ 0.0)
+
+  def new(%Term{} = term, constant) do
+    new([term], constant)
+  end
+
+  def new(terms, constant) when is_list(terms) do
+    %Expression{terms: terms, constant: constant}
+  end
+
+  @spec from(t() | Variable.t() | number()) :: t()
+  def from(%Expression{} = expr), do: expr
+  def from(%Variable{} = var), do: new(Term.new(var, 1.0))
+  def from(number) when is_number(number), do: new([], number)
+
+  @spec add(t() | Variable.t() | number(), t() | Variable.t() | number()) :: t()
+  def add(a, b) do
+    a = from(a)
+    b = from(b)
+
+    new(a.terms ++ b.terms, a.constant + b.constant)
+  end
+
+  @spec subtract(t() | Variable.t() | number(), t() | Variable.t() | number()) :: t()
+  def subtract(a, b) do
+    a = from(a)
+    b = from(b)
+
+    negated_terms =
+      Enum.map(b.terms, fn %Term{variable: v, coefficient: c} ->
+        Term.new(v, -c)
+      end)
+
+    new(a.terms ++ negated_terms, a.constant - b.constant)
+  end
+
+  def multiply(%Expression{terms: terms, constant: constant}, factor)
+      when is_number(factor) do
+    new_terms =
+      Enum.map(terms, fn %Term{variable: v, coefficient: c} ->
+        %Term{variable: v, coefficient: c * factor}
+      end)
+
+    new(new_terms, constant * factor)
+  end
+
+  def divide(%Expression{} = expr, factor) do
+    multiply(expr, 1 / factor)
+  end
+
+  def pretty_print(%Expression{} = expression) do
+    expression.terms
+    |> Enum.map(&Term.pretty_print/1)
+    |> Enum.intersperse(" + ")
+    |> List.insert_at(-1, expression.constant)
+  end
+end

--- a/lib/cassowary/row.ex
+++ b/lib/cassowary/row.ex
@@ -1,0 +1,115 @@
+defmodule Cassowary.Row do
+  alias Cassowary.{Symbol, Util}
+
+  @type t() :: %__MODULE__{constant: float(), cells: map()}
+
+  @enforce_keys :constant
+  defstruct [:constant, cells: %{}]
+
+  def new(constant) when is_float(constant) do
+    %__MODULE__{constant: constant}
+  end
+
+  @spec insert_row(t(), t(), float()) :: {t(), boolean()}
+  def insert_row(%__MODULE__{} = row, %__MODULE__{} = other, coefficient) do
+    constant_diff = other.constant * coefficient
+
+    row = Map.put(row, :constant, row.constant + constant_diff)
+
+    row =
+      Enum.reduce(other.cells, row, fn {s, v}, r ->
+        insert_symbol(r, s, v * coefficient)
+      end)
+
+    {row, constant_diff != 0.0}
+  end
+
+  @spec insert_symbol(t(), Cassowary.Symbol.t(), float()) :: t()
+  def insert_symbol(row, symbol, coefficient) do
+    {_cell, cells} =
+      Map.get_and_update(row.cells, symbol, fn
+        nil ->
+          if Util.near_zero?(coefficient) do
+            :pop
+          else
+            {coefficient, coefficient}
+          end
+
+        coeff ->
+          coeff = coeff + coefficient
+
+          if Util.near_zero?(coeff) do
+            :pop
+          else
+            {coeff, coeff}
+          end
+      end)
+
+    Map.put(row, :cells, cells)
+  end
+
+  @spec reverse_sign(t()) :: t()
+  def reverse_sign(row) do
+    row
+    |> Map.put(:constant, -row.constant)
+    |> Map.update!(:cells, fn cells ->
+      Enum.map(cells, fn {symbol, coeff} ->
+        {symbol, -coeff}
+      end)
+      |> Map.new()
+    end)
+  end
+
+  @spec coefficient_for(t(), Symbol.t()) :: float()
+  def coefficient_for(row, symbol) do
+    Map.get(row.cells, symbol, 0.0)
+  end
+
+  @spec substitute(t(), Symbol.t(), t) :: {t(), boolean()}
+  def substitute(row, symbol, other_row) do
+    {coeff, cells} = Map.pop(row.cells, symbol)
+    row = Map.put(row, :cells, cells)
+
+    if coeff do
+      insert_row(row, other_row, coeff)
+    else
+      {row, false}
+    end
+  end
+
+  @spec solve_for_symbol(t(), Symbol.t()) :: t()
+  def solve_for_symbol(row, symbol) do
+    {old_coeff, row} =
+      Map.get_and_update!(row, :cells, fn cells ->
+        Map.pop!(cells, symbol)
+      end)
+
+    factor = -1.0 / old_coeff
+
+    row = Map.put(row, :constant, row.constant * factor)
+
+    Map.update!(row, :cells, &Map.new(&1, fn {sym, coeff} -> {sym, coeff * factor} end))
+  end
+
+  @spec solve_for_symbols(t(), Symbol.t(), Symbol.t()) :: t()
+  def solve_for_symbols(row, lhs, rhs) do
+    row = insert_symbol(row, lhs, -1.0)
+    solve_for_symbol(row, rhs)
+  end
+
+  @spec remove(t(), Symbol.t()) :: t()
+  def remove(row, symbol) do
+    Map.update!(row, :cells, fn cells ->
+      Map.delete(cells, symbol)
+    end)
+  end
+
+  def pretty_row(%Cassowary.Row{constant: const, cells: cells}) do
+    cell_str =
+      cells
+      |> Enum.map(fn {s, c} -> "#{s.kind}-#{s.id}: #{c}" end)
+      |> Enum.join(", ")
+
+    IO.puts("Row(constant=#{const}, cells=[#{cell_str}])")
+  end
+end

--- a/lib/cassowary/solver.ex
+++ b/lib/cassowary/solver.ex
@@ -1,0 +1,513 @@
+defmodule Cassowary.Solver do
+  alias __MODULE__
+  alias Cassowary.{Constraint, Variable, Symbol, Row, Strength, Tag, Util}
+
+  @type t() :: %Solver{
+          constraints: map(),
+          var_data: map(),
+          var_for_symbol: map(),
+          rows: map(),
+          id_tick: pos_integer(),
+          objective: Row.t(),
+          artificial: nil | Row.t(),
+          should_clear_changes: boolean(),
+          changed: MapSet.t(Variable.t()),
+          infeasible_rows: [Symbol.t()],
+          public_changes: [{Variable.t(), number()}]
+        }
+
+  defstruct constraints: %{},
+            var_data: %{},
+            var_for_symbol: %{},
+            rows: %{},
+            id_tick: 1,
+            objective: Row.new(0.0),
+            artificial: nil,
+            should_clear_changes: false,
+            changed: MapSet.new(),
+            infeasible_rows: [],
+            public_changes: []
+
+  @spec new() :: t()
+  def new(), do: %Solver{}
+
+  @spec add_constraint(t(), Constraint.t()) :: {:ok, t()} | {:error, atom()}
+  def add_constraint(solver, %Constraint{} = constraint) do
+    with false <- Map.has_key?(solver.constraints, constraint) do
+      {solver, row, tag} = create_row(solver, constraint)
+      subject = choose_subject(row, tag)
+
+      res =
+        if subject.kind == :invalid && all_dummies?(row) do
+          if !Util.near_zero?(row.constant) do
+            {:error, :unsatisfiable_constraint}
+          else
+            {:ok, tag.marker}
+          end
+        else
+          {:ok, subject}
+        end
+
+      case res do
+        {:ok, subject} ->
+          res =
+            if subject.kind == :invalid do
+              case add_with_artificial_variable?(solver, row) do
+                {:ok, solver, satisfiable} ->
+                  if !satisfiable do
+                    {:error, :unsatisfiable_constraint}
+                  else
+                    {:ok, solver}
+                  end
+
+                {:error, reason} ->
+                  {:error, reason}
+              end
+            else
+              row = Row.solve_for_symbol(row, subject)
+
+              solver = substitute(solver, subject, row)
+
+              solver =
+                if subject.kind == :external && row.constant != 0.0 do
+                  v = Map.fetch!(solver.var_for_symbol, subject)
+                  variable_changed(solver, v)
+                else
+                  solver
+                end
+
+              solver =
+                Map.update!(solver, :rows, fn rows ->
+                  Map.put(rows, subject, row)
+                end)
+
+              {:ok, solver}
+            end
+
+          case res do
+            {:ok, solver} ->
+              solver
+              |> Map.update!(:constraints, &Map.put(&1, constraint, tag))
+              |> optimize(:objective)
+
+            {:error, reason} ->
+              {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    else
+      true -> {:error, :duplicate_constraint}
+    end
+  end
+
+  @spec fetch_changes(t()) :: t()
+  def fetch_changes(%Solver{} = solver) do
+    solver =
+      if solver.should_clear_changes do
+        solver
+        |> Map.put(:changed, MapSet.new())
+        |> Map.put(:should_clear_changes, false)
+      else
+        Map.put(solver, :should_clear_changes, true)
+      end
+
+    solver = Map.put(solver, :public_changes, [])
+
+    public_changes =
+      Enum.reduce(solver.changed, [], fn variable, acc ->
+        case Map.fetch(solver.var_data, variable) do
+          {:ok, {old_value, symbol, _}} ->
+            new_value =
+              case Map.fetch(solver.rows, symbol) do
+                {:ok, row} -> row.constant
+                :error -> 0.0
+              end
+
+            if old_value != new_value do
+              [{variable, new_value} | acc]
+            else
+              solver
+            end
+
+          :error ->
+            acc
+        end
+      end)
+
+    Map.put(solver, :public_changes, public_changes)
+  end
+
+  def pretty_print(solver) do
+    solver.constraints
+    |> Map.keys()
+    |> Enum.each(&IO.puts(Constraint.pretty_print(&1)))
+  end
+
+  @spec create_row(t(), Constraint.t()) :: {t(), Row.t(), Tag.t()}
+  defp create_row(%__MODULE__{} = solver, constraint) do
+    expr = constraint.expression
+    row = Row.new(expr.constant)
+
+    {solver, row} =
+      Enum.reduce(expr.terms, {solver, row}, fn term, {solver, row} ->
+        if !Cassowary.Util.near_zero?(term.coefficient) do
+          {solver, symbol} = get_var_symbol(solver, term.variable)
+
+          other_row = Map.get(solver.rows, symbol)
+
+          row =
+            if other_row do
+              {r, _} = Row.insert_row(row, other_row, term.coefficient)
+              r
+            else
+              Row.insert_symbol(row, symbol, term.coefficient)
+            end
+
+          {solver, row}
+        else
+          {solver, row}
+        end
+      end)
+
+    {solver, row, tag} =
+      case constraint.operator do
+        :<= ->
+          coeff = 1.0
+          slack = Symbol.new(solver.id_tick, :slack)
+          solver = Map.put(solver, :id_tick, solver.id_tick + 1)
+          row = Row.insert_symbol(row, slack, coeff)
+
+          if constraint.strength < Strength.required() do
+            error = Symbol.new(solver.id_tick, :error)
+            solver = Map.put(solver, :id_tick, solver.id_tick + 1)
+            row = Row.insert_symbol(row, error, -coeff)
+
+            solver =
+              Map.update!(solver, :objective, fn objective ->
+                Row.insert_symbol(objective, error, constraint.strength)
+              end)
+
+            {solver, row, %Tag{marker: slack, other: error}}
+          else
+            {solver, row, %Tag{marker: slack, other: Symbol.invalid()}}
+          end
+
+        :>= ->
+          coeff = -1.0
+          slack = Symbol.new(solver.id_tick, :slack)
+          solver = Map.put(solver, :id_tick, solver.id_tick + 1)
+          row = Row.insert_symbol(row, slack, coeff)
+
+          if(constraint.strength < Strength.required()) do
+            error = Symbol.new(solver.id_tick, :error)
+            solver = Map.put(solver, :id_tick, solver.id_tick + 1)
+            row = Row.insert_symbol(row, error, -coeff)
+
+            solver =
+              Map.update!(solver, :objective, fn objective ->
+                Row.insert_symbol(objective, error, constraint.strength)
+              end)
+
+            {solver, row, %Tag{marker: slack, other: error}}
+          else
+            {solver, row, %Tag{marker: slack, other: Symbol.invalid()}}
+          end
+
+        :== ->
+          if constraint.strength < Strength.required() do
+            errplus = Symbol.new(solver.id_tick, :error)
+            solver = Map.put(solver, :id_tick, solver.id_tick + 1)
+            errminus = Symbol.new(solver.id_tick, :error)
+            solver = Map.put(solver, :id_tick, solver.id_tick + 1)
+            row = Row.insert_symbol(row, errplus, -1.0)
+            row = Row.insert_symbol(row, errminus, 1.0)
+
+            solver =
+              Map.update!(solver, :objective, fn objective ->
+                objective
+                |> Row.insert_symbol(errplus, constraint.strength)
+                |> Row.insert_symbol(errminus, constraint.strength)
+              end)
+
+            {solver, row, %Tag{marker: errplus, other: errminus}}
+          else
+            dummy = Symbol.new(solver.id_tick, :dummy)
+            solver = Map.put(solver, :id_tick, solver.id_tick + 1)
+            row = Row.insert_symbol(row, dummy, 1.0)
+            {solver, row, %Tag{marker: dummy, other: Symbol.invalid()}}
+          end
+      end
+
+    row =
+      if row.constant < 0.0 do
+        Row.reverse_sign(row)
+      else
+        row
+      end
+
+    {solver, row, tag}
+  end
+
+  @spec get_var_symbol(t(), Variable.t()) :: {t(), Symbol.t()}
+  defp get_var_symbol(solver, variable) do
+    case Map.fetch(solver.var_data, variable) do
+      {:ok, {value, symbol, refcount}} ->
+        solver =
+          Map.update!(solver, :var_data, &Map.put(&1, variable, {value, symbol, refcount + 1}))
+
+        {solver, symbol}
+
+      :error ->
+        symbol = Symbol.new(solver.id_tick, :external)
+
+        solver =
+          solver
+          |> Map.put(:id_tick, solver.id_tick + 1)
+          |> Map.update!(:var_data, &Map.put(&1, variable, {:nan, symbol, 1}))
+          |> Map.update!(:var_for_symbol, &Map.put(&1, symbol, variable))
+
+        {solver, symbol}
+    end
+  end
+
+  @spec choose_subject(Row.t(), Tag.t()) :: Symbol.t()
+  defp choose_subject(row, tag) do
+    symbol =
+      row.cells
+      |> Map.keys()
+      |> Enum.find(&(&1.kind == :external))
+
+    if symbol do
+      symbol
+    else
+      symbol =
+        if tag.marker.kind in [:slack, :error] && Row.coefficient_for(row, tag.marker) < 0.0 do
+          tag.marker
+        end
+
+      if symbol do
+        symbol
+      else
+        symbol =
+          if tag.other.kind in [:slack, :error] && Row.coefficient_for(row, tag.marker) < 0.0 do
+            tag.other
+          end
+
+        if symbol do
+          symbol
+        else
+          Symbol.invalid()
+        end
+      end
+    end
+  end
+
+  @spec all_dummies?(Row.t()) :: boolean()
+  defp all_dummies?(row) do
+    row.cells
+    |> Map.keys()
+    |> Enum.all?(&(&1.kind == :dummy))
+  end
+
+  @spec add_with_artificial_variable?(t(), Row.t()) :: {:ok, t(), boolean()} | {:error, atom()}
+  defp add_with_artificial_variable?(solver, row) do
+    art = Symbol.new(solver.id_tick, :slack)
+
+    solver =
+      solver
+      |> Map.put(:id_tick, solver.id_tick + 1)
+      |> Map.update!(:rows, &Map.put(&1, art, row))
+      |> Map.put(:artificial, row)
+
+    case optimize(solver, :artificial) do
+      {:ok, solver} ->
+        success = Util.near_zero?(solver.artificial.constant)
+
+        solver = Map.put(solver, :artificial, nil)
+
+        res =
+          Map.get_and_update(solver, :rows, fn rows ->
+            Map.pop(rows, art)
+          end)
+
+        res =
+          case res do
+            {nil, solver} ->
+              {:ok, solver, success}
+
+            {row, solver} ->
+              if row.cells == [] do
+                {:return, solver, success}
+              else
+                entering = any_pivotable_symbol(row)
+
+                if entering.kind == :invalid do
+                  {:return, solver, false}
+                else
+                  row = Row.solve_for_symbols(row, art, entering)
+
+                  solver = substitute(solver, entering, row)
+
+                  Map.put(solver, :rows, Map.put(solver.rows, entering, row))
+                  {:ok, solver, success}
+                end
+              end
+          end
+
+        case res do
+          {:return, solver, success} ->
+            {:ok, solver, success}
+
+          {:ok, solver, success} ->
+            solver =
+              Map.update!(solver, :rows, fn rows ->
+                rows
+                |> Enum.map(fn {k, row} ->
+                  {k, Row.remove(row, art)}
+                end)
+                |> Map.new()
+              end)
+
+            solver = Map.put(solver, :objective, Row.remove(solver.objective, art))
+
+            {:ok, solver, success}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @spec optimize(t(), :objective | :artificial) :: {:ok, t()} | {:error, atom()}
+  defp optimize(solver, objective_type) do
+    objective = Map.get(solver, objective_type)
+
+    case get_entering_symbol(objective) do
+      %Symbol{kind: :invalid} ->
+        {:ok, solver}
+
+      entering ->
+        case get_leaving_row(solver, entering) do
+          {_solver, nil, nil} ->
+            {:error, :objective_unbounded}
+
+          {solver, leaving, row} ->
+            row = Row.solve_for_symbols(row, leaving, entering)
+            solver = substitute(solver, entering, row)
+
+            solver =
+              if entering.kind == :external && row.constant != 0.0 do
+                variable = Map.fetch!(solver.var_for_symbol, entering)
+
+                variable_changed(solver, variable)
+              else
+                solver
+              end
+
+            solver = Map.put(solver, :rows, Map.put(solver.rows, entering, row))
+
+            optimize(solver, objective_type)
+        end
+    end
+  end
+
+  @spec get_entering_symbol(Row.t()) :: Symbol.t()
+  defp get_entering_symbol(objective) do
+    Enum.reduce_while(objective.cells, Symbol.invalid(), fn {symbol, value}, invalid ->
+      if symbol.kind != :dummy and value < 0.0 do
+        {:halt, symbol}
+      else
+        {:cont, invalid}
+      end
+    end)
+  end
+
+  @spec get_leaving_row(t(), Symbol.t()) :: {t(), Symbol.t() | nil, Row.t() | nil}
+  def get_leaving_row(solver, entering) do
+    {_, symbol} =
+      Enum.reduce(solver.rows, {Float.max_finite(), nil}, fn {sym, row}, {best_ratio, best_sym} ->
+        cond do
+          sym.kind == :external ->
+            {best_ratio, best_sym}
+
+          (coef = Row.coefficient_for(row, entering)) < 0.0 ->
+            ratio = -row.constant / coef
+            if ratio < best_ratio, do: {ratio, sym}, else: {best_ratio, best_sym}
+
+          true ->
+            {best_ratio, best_sym}
+        end
+      end)
+
+    if symbol do
+      {row, solver} = Map.get_and_update!(solver, :rows, &Map.pop!(&1, symbol))
+      {solver, symbol, row}
+    else
+      {solver, nil, nil}
+    end
+  end
+
+  @spec substitute(t(), Symbol.t(), Row.t()) :: t()
+  defp substitute(solver, symbol, row) do
+    solver =
+      Enum.reduce(solver.rows, solver, fn {other_symbol, other_row}, solver ->
+        {new_row, constant_changed} = Row.substitute(other_row, symbol, row)
+
+        solver = put_in(solver.rows[other_symbol], new_row)
+
+        solver =
+          if other_symbol.kind == :external && constant_changed do
+            variable = Map.fetch!(solver.var_for_symbol, other_symbol)
+
+            variable_changed(solver, variable)
+          else
+            solver
+          end
+
+        if other_symbol.kind != :external && new_row.constant < 0.0 do
+          Map.put(
+            solver,
+            :infeasible_rows,
+            List.insert_at(solver.infeasible_rows, -1, other_symbol)
+          )
+        else
+          solver
+        end
+      end)
+
+    {objective, _} = Row.substitute(solver.objective, symbol, row)
+    solver = Map.put(solver, :objective, objective)
+
+    if solver.artificial do
+      {artificial, _} = Row.substitute(solver.artificial, symbol, row)
+      Map.put(solver, :artificial, artificial)
+    else
+      solver
+    end
+  end
+
+  @spec variable_changed(t(), Variable.t()) :: t()
+  defp variable_changed(solver, variable) do
+    solver =
+      if solver.should_clear_changes do
+        solver
+        |> Map.put(:changed, MapSet.new())
+        |> Map.put(:should_clear_changes, false)
+      else
+        solver
+      end
+
+    Map.update!(solver, :changed, &MapSet.put(&1, variable))
+  end
+
+  @spec any_pivotable_symbol(Row.t()) :: Symbol.t()
+  defp any_pivotable_symbol(row) do
+    row.cells
+    |> Map.keys()
+    |> Enum.find(Symbol.invalid(), fn symbol ->
+      symbol.kind == :slack || symbol.kind == :error
+    end)
+  end
+end

--- a/lib/cassowary/strength.ex
+++ b/lib/cassowary/strength.ex
@@ -1,0 +1,20 @@
+defmodule Cassowary.Strength do
+  @type t :: float()
+
+  @required 1_000_000_000.0
+  def required(), do: @required
+  @strong 1000.0
+  def strong(), do: @strong
+  @medium 1.0
+  def medium(), do: @medium
+  @weak 0.001
+  def weak(), do: @weak
+
+  defguard is_strength(strength) when strength >= @weak and strength <= @required
+
+  def new(strength) when is_float(strength) do
+    strength
+    |> max(weak())
+    |> min(required())
+  end
+end

--- a/lib/cassowary/symbol.ex
+++ b/lib/cassowary/symbol.ex
@@ -1,0 +1,17 @@
+defmodule Cassowary.Symbol do
+  @type kind() :: :invalid | :external | :slack | :error | :dummy
+  @type t() :: %__MODULE__{id: pos_integer(), kind: kind()}
+
+  @enforce_keys [:kind]
+  defstruct [:kind, id: 0]
+
+  @kinds ~w[invalid external slack error dummy]a
+
+  def new(id, kind) when is_integer(id) and kind in @kinds do
+    %__MODULE__{id: id, kind: kind}
+  end
+
+  def invalid do
+    %__MODULE__{kind: :invalid}
+  end
+end

--- a/lib/cassowary/tag.ex
+++ b/lib/cassowary/tag.ex
@@ -1,0 +1,8 @@
+defmodule Cassowary.Tag do
+  alias Cassowary.Symbol
+
+  @type t() :: %__MODULE__{marker: Symbol.t(), other: Symbol.t()}
+
+  @enforce_keys [:marker, :other]
+  defstruct [:marker, :other]
+end

--- a/lib/cassowary/term.ex
+++ b/lib/cassowary/term.ex
@@ -1,0 +1,25 @@
+defmodule Cassowary.Term do
+  alias __MODULE__
+  alias Cassowary.Variable
+
+  @type t() :: %Term{variable: Variable.t(), coefficient: float()}
+
+  @enforce_keys [:variable, :coefficient]
+  defstruct [:variable, :coefficient]
+
+  alias Cassowary.Variable
+
+  @spec new(Variable.t(), float()) :: t()
+  def new(%Variable{} = variable, coefficient \\ 1.0) do
+    %Term{variable: variable, coefficient: coefficient}
+  end
+
+  @spec negate(t()) :: t()
+  def negate(%Term{variable: v, coefficient: c}) do
+    %Term{variable: v, coefficient: -c}
+  end
+
+  def pretty_print(%Term{variable: variable, coefficient: coefficient}) do
+    "(#{coefficient}) * v#{variable.id}"
+  end
+end

--- a/lib/cassowary/util.ex
+++ b/lib/cassowary/util.ex
@@ -1,0 +1,4 @@
+defmodule Cassowary.Util do
+  @epsilon 1.0e-8
+  def near_zero?(value, epsilon \\ @epsilon) when is_float(value), do: abs(value) < epsilon
+end

--- a/lib/cassowary/variable.ex
+++ b/lib/cassowary/variable.ex
@@ -1,0 +1,23 @@
+defmodule Cassowary.Variable do
+  @type t() :: %__MODULE__{id: pos_integer()}
+
+  @enforce_keys [:id]
+  defstruct [:id]
+
+  @spec new(integer()) :: t()
+  def new(id \\ __MODULE__.ID.id()) do
+    %__MODULE__{id: id}
+  end
+end
+
+defmodule Cassowary.Variable.ID do
+  use Agent
+
+  def start_link(_) do
+    Agent.start_link(fn -> 0 end, name: __MODULE__)
+  end
+
+  def id do
+    Agent.get_and_update(__MODULE__, &{&1, &1 + 1})
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -22,6 +22,7 @@ defmodule BackBreeze.MixProject do
 
   def application do
     [
+      mod: {BackBreeze.Application, []},
       extra_applications: [:logger]
     ]
   end


### PR DESCRIPTION
- Partially implemented Cassowary solver (only the necessary logic for TUI layouts)
- Added `Layout` and `Rect` modules to BackBreeze, along with all associated layout modules
- Added IEx helpers for quick recompilation: • `BackBreeze.IExHelpers.r/0` → recompile() • `BackBreeze.IExHelpers.rf/0` → recompile(force: true)

example
```elixir
alias BackBreeze.Layout
alias BackBreeze.Layout.Constraint
alias BackBreeze.Rect

horizontal = 
  Layout.horizontal()
  |> Layout.constraints([Constraint.percentage(25), Constraint.percentage(50), Constraint.percentage(25)])
  |> Layout.split(Rect.new(0, 0, 200, 200))
=>  [
  %BackBreeze.Rect{x: 0, y: 0, width: 50, height: 200},
  %BackBreeze.Rect{x: 50, y: 0, width: 100, height: 200},
  %BackBreeze.Rect{x: 150, y: 0, width: 50, height: 200}
]

middle = Enum.at(horizontal, 1)
=> %BackBreeze.Rect{x: 50, y: 0, width: 100, height: 200}

vertical =
  Layout.vertical()
  |> Layout.constraints([Constraint.percentage(25), Constraint.percentage(50), Constraint.percentage(25)])
  |> Layout.split(middle)
=> [
  %BackBreeze.Rect{x: 50, y: 0, width: 100, height: 50},
  %BackBreeze.Rect{x: 50, y: 50, width: 100, height: 100},
  %BackBreeze.Rect{x: 50, y: 150, width: 100, height: 50}
] 

center_rect = Enum.at(vertical, 1)
=> %BackBreeze.Rect{x: 50, y: 50, width: 100, height: 100},
```
```
Horizontal: 25% | 50% | 25%  => 50 | 100 | 50
Vertical:   25% | 50% | 25%  => 50 | 100 | 50

Visual representation (each symbol ≈ 25 units):

Full area (200x200):
┌──────────────────────┐
│      empty 25%       │  
├───────┬─────────┬────┤
│       │         │    │
│  empty│  center │empty│  
│  25%  │ 50%     │25% │
│       │         │    │
├───────┴─────────┴────┤
│      empty 25%       │  
└──────────────────────┘
```

Sorry, My English is not so good but I can try to describe this PR
I tried add something like [ratatui](https://github.com/ratatui/ratatui) layout system
Ratatui uses the [kasuari](https://github.com/ratatui/kasuari), which implements the [Cassowary algorithm](https://en.wikipedia.org/wiki/Cassowary_(software)).

Right now the code is in bad shape but if you are interesting in it, I can improve code quality and add tests.
After that I can try to integrate it in your modules. 
if you are not interesting in it, so it was pretty good experience. I understood that I am dumb for this algorithm 🫨 

I also added `r` and `rf` helpers that recompile project  