### PR TITLE
feat(scrollbar): add configurable viewport scrollbars for overflow-hidden boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ BackBreeze.Box.new(
 Supported scrollbar shorthands remain available:
 `false | true | :vertical | :horizontal | :both`.
 
-By default, scrollbar thumbs are single-cell and in `:inset` mode they render on the
-border gutter when a border exists, preserving content columns.
+By default, scrollbar thumbs scale proportionally to viewport/content size. You can
+override with `sizing: {:fixed, n}` if you want fixed-size thumbs. In `:inset` mode,
+scrollbars render on the border gutter when a border exists, preserving content columns.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,36 @@ A terminal layout rendering library built on top of [Termite](https://github.com
  * text reflowing/overflow
  * text offsets to allow for scrolling
  * optional viewport scrollbars for overflow-hidden regions
+ * configurable scrollbar axis/placement/chars/colors/arrows
  * joining text horizontally/vertically
  * grid based rendering
  * absolute positioning
+
+## Scrollbar configuration
+
+```elixir
+BackBreeze.Box.new(
+  style: %{
+    border: :line,
+    width: 30,
+    height: 8,
+    overflow: :hidden,
+    scrollbar: %{
+      axis: :both,
+      show: :auto,
+      placement: :end,
+      arrows: true,
+      thumb: %{char: "▓", foreground_color: 2, bold: true},
+      track: %{char: "·", foreground_color: 8}
+    }
+  },
+  scroll: {3, 10},
+  children: [BackBreeze.Box.new(content: "...")]
+)
+```
+
+Supported scrollbar shorthands remain available:
+`false | true | :vertical | :horizontal | :both`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ BackBreeze.Box.new(
 Supported scrollbar shorthands remain available:
 `false | true | :vertical | :horizontal | :both`.
 
+By default, scrollbar thumbs are single-cell and in `:inset` mode they render on the
+border gutter when a border exists, preserving content columns.
+
 ## Installation
 
 He package can be installed by adding `back_breeze` to your list of dependencies in `mix.exs`:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A terminal layout rendering library built on top of [Termite](https://github.com
  * ANSI colors and text styling
  * text reflowing/overflow
  * text offsets to allow for scrolling
+ * optional viewport scrollbars for overflow-hidden regions
  * joining text horizontally/vertically
  * grid based rendering
  * absolute positioning

--- a/examples/overflow.exs
+++ b/examples/overflow.exs
@@ -46,9 +46,20 @@ IO.puts(box.content)
 
 child =
   BackBreeze.Box.new(%{
-    style: %{border: :line, width: 30, height: 5, overflow: :hidden, scrollbar: true},
+    style: %{
+      border: :line,
+      width: 30,
+      height: 5,
+      overflow: :hidden,
+      scrollbar: %{
+        axis: :vertical,
+        arrows: true,
+        thumb: %{char: "▓", foreground_color: 2, bold: true},
+        track: %{char: "·", foreground_color: 8}
+      }
+    },
     scroll: {2, 0},
-    content: "3 box WITH SCROLLBAR #{content}"
+    content: "3 box WITH CONFIGURED SCROLLBAR #{content}"
   })
 
 box = BackBreeze.Box.new(style: %{border: :line}, children: [child]) |> BackBreeze.Box.render()

--- a/examples/overflow.exs
+++ b/examples/overflow.exs
@@ -43,3 +43,14 @@ child =
 box = BackBreeze.Box.new(style: %{border: :line}, children: [child]) |> BackBreeze.Box.render()
 
 IO.puts(box.content)
+
+child =
+  BackBreeze.Box.new(%{
+    style: %{border: :line, width: 30, height: 5, overflow: :hidden, scrollbar: true},
+    scroll: {2, 0},
+    content: "3 box WITH SCROLLBAR #{content}"
+  })
+
+box = BackBreeze.Box.new(style: %{border: :line}, children: [child]) |> BackBreeze.Box.render()
+
+IO.puts(box.content)

--- a/examples/overflow.exs
+++ b/examples/overflow.exs
@@ -49,7 +49,7 @@ child =
     style: %{
       border: :line,
       width: 30,
-      height: 5,
+      height: 30,
       overflow: :hidden,
       scrollbar: %{
         axis: :vertical,
@@ -59,7 +59,7 @@ child =
       }
     },
     scroll: {2, 0},
-    content: "3 box WITH CONFIGURED SCROLLBAR #{content}"
+    content: "3 box WITH CONFIGURED SCROLLBAR #{String.duplicate(content, 4)}"
   })
 
 box = BackBreeze.Box.new(style: %{border: :line}, children: [child]) |> BackBreeze.Box.render()

--- a/examples/scrollbar.exs
+++ b/examples/scrollbar.exs
@@ -1,0 +1,79 @@
+render = fn title, box ->
+  IO.puts("\n#{title}")
+  IO.puts(String.duplicate("=", String.length(title)))
+  IO.puts(box |> BackBreeze.Box.render() |> Map.get(:content))
+end
+
+vertical_content =
+  Enum.map_join(1..14, "\n", fn row ->
+    "Row #{row}: Lorem ipsum"
+  end)
+
+vertical_height = 5
+vertical_line_count = vertical_content |> String.split("\n") |> length()
+max_vertical_scroll = max(vertical_line_count - vertical_height, 0)
+
+vertical_top =
+  BackBreeze.Box.new(
+    content: vertical_content,
+    scroll: {0, 0},
+    style: %{
+      border: :line,
+      width: 20,
+      height: vertical_height,
+      overflow: :hidden,
+      scrollbar: true
+    }
+  )
+
+vertical_bottom =
+  BackBreeze.Box.new(
+    content: vertical_content,
+    scroll: {max_vertical_scroll, 0},
+    style: %{
+      border: :line,
+      width: 20,
+      height: vertical_height,
+      overflow: :hidden,
+      scrollbar: true
+    }
+  )
+
+horizontal =
+  BackBreeze.Box.new(
+    content: "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    scroll: {0, 10},
+    style: %{
+      border: :line,
+      width: 18,
+      height: 2,
+      overflow: :hidden,
+      scrollbar: %{axis: :horizontal}
+    }
+  )
+
+both_axes =
+  BackBreeze.Box.new(
+    content:
+      Enum.map_join(1..8, "\n", fn row ->
+        "L#{row}: ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      end),
+    scroll: {2, 7},
+    style: %{
+      border: :line,
+      width: 18,
+      height: 4,
+      overflow: :hidden,
+      scrollbar: %{
+        axis: :both,
+        arrows: true,
+        thumb: %{char: "▓", foreground_color: 2, bold: true},
+        track: %{char: "·", foreground_color: 8}
+      }
+    }
+  )
+
+render.("Vertical scrollbar thumb at top (scroll: {0, 0})", vertical_top)
+render.("Vertical scrollbar thumb at bottom (max scroll)", vertical_bottom)
+render.("Horizontal scrollbar", horizontal)
+render.("Both axes with arrows + custom thumb/track", both_axes)

--- a/lib/back_breeze/box.ex
+++ b/lib/back_breeze/box.ex
@@ -84,8 +84,10 @@ defmodule BackBreeze.Box do
   defp render_and_calc(%{box: %{children: []} = box} = acc, opts) do
     {content, dimensions, width} = render_self(box, opts)
 
+    scrollbar_config = BackBreeze.Scrollbar.normalize(box.style.scrollbar, box.style)
+
     {content, width, layer_map} =
-      if vertical_scrollbar?(box.style, dimensions) do
+      if box.style.overflow == :hidden and scrollbar_config.enabled do
         {layer_map, max_width, max_height} = generate_layer_map(content, %{}, 0, 0)
 
         layer_map =
@@ -93,7 +95,10 @@ defmodule BackBreeze.Box do
             layer_map,
             box.style,
             box.scroll,
-            dimensions,
+            %{
+              content_height: dimensions.content_height,
+              content_width: raw_content_width(box.content)
+            },
             max_width,
             max_height
           )
@@ -188,7 +193,7 @@ defmodule BackBreeze.Box do
         child_layer_map,
         box.style,
         box.scroll,
-        dimensions,
+        %{content_height: dimensions.content_height, content_width: child_width},
         max_width,
         max_height
       )
@@ -430,72 +435,376 @@ defmodule BackBreeze.Box do
     Enum.join(content, "\n") |> String.trim_trailing("\n")
   end
 
-  defp maybe_add_scrollbars(layer_map, style, scroll, dimensions, max_x, max_y) do
-    if vertical_scrollbar?(style, dimensions) do
-      add_vertical_scrollbar(layer_map, style, scroll, dimensions, max_x, max_y)
-    else
-      layer_map
+  defp maybe_add_scrollbars(layer_map, style, scroll, metrics, max_x, max_y) do
+    config = BackBreeze.Scrollbar.normalize(style.scrollbar, style)
+
+    cond do
+      style.overflow != :hidden or !config.enabled ->
+        layer_map
+
+      !is_integer(max_x) or !is_integer(max_y) ->
+        layer_map
+
+      true ->
+        {left, top, right, bottom} = viewport_bounds(style.border, max_x, max_y)
+
+        viewport_width = max(right - left + 1, 0)
+        viewport_height = max(bottom - top + 1, 0)
+
+        content_height = max(Map.get(metrics, :content_height, viewport_height), viewport_height)
+        content_width = max(Map.get(metrics, :content_width, viewport_width), viewport_width)
+
+        {vertical?, horizontal?, eff_viewport_width, eff_viewport_height} =
+          resolve_visible_axes(
+            config,
+            content_width,
+            content_height,
+            viewport_width,
+            viewport_height
+          )
+
+        if !vertical? and !horizontal? do
+          layer_map
+        else
+          vertical_placement = BackBreeze.Scrollbar.placement(config, :vertical)
+          horizontal_placement = BackBreeze.Scrollbar.placement(config, :horizontal)
+
+          x_scrollbar = if vertical_placement == :start, do: left, else: right
+          y_scrollbar = if horizontal_placement == :start, do: top, else: bottom
+
+          {vertical_start, vertical_end} =
+            trim_axis_for_intersection(top, bottom, horizontal?, horizontal_placement)
+
+          {horizontal_start, horizontal_end} =
+            trim_axis_for_intersection(left, right, vertical?, vertical_placement)
+
+          layer_map =
+            if config.mode == :inset and vertical? do
+              clear_vertical_strip(layer_map, x_scrollbar, vertical_start, vertical_end)
+            else
+              layer_map
+            end
+
+          layer_map =
+            if config.mode == :inset and horizontal? do
+              clear_horizontal_strip(layer_map, y_scrollbar, horizontal_start, horizontal_end)
+            else
+              layer_map
+            end
+
+          {scroll_top, scroll_left} = normalize_scroll(scroll)
+
+          layer_map =
+            if vertical? do
+              draw_vertical_scrollbar(
+                layer_map,
+                config,
+                x_scrollbar,
+                vertical_start,
+                vertical_end,
+                scroll_top,
+                content_height,
+                eff_viewport_height
+              )
+            else
+              layer_map
+            end
+
+          layer_map =
+            if horizontal? do
+              draw_horizontal_scrollbar(
+                layer_map,
+                config,
+                y_scrollbar,
+                horizontal_start,
+                horizontal_end,
+                scroll_left,
+                content_width,
+                eff_viewport_width
+              )
+            else
+              layer_map
+            end
+
+          maybe_draw_intersection(
+            layer_map,
+            config,
+            vertical?,
+            horizontal?,
+            x_scrollbar,
+            y_scrollbar
+          )
+        end
     end
   end
 
-  defp vertical_scrollbar?(
-         %{overflow: :hidden, scrollbar: scrollbar},
-         %{content_height: content_height, viewport_height: viewport_height}
-       )
-       when scrollbar in [true, :vertical, :both] and is_integer(content_height) and
-              is_integer(viewport_height) do
-    content_height > viewport_height and viewport_height > 0
-  end
-
-  defp vertical_scrollbar?(_style, _dimensions), do: false
-
-  defp add_vertical_scrollbar(
-         layer_map,
-         %{border: border},
-         {scroll_top, _},
-         dimensions,
-         max_x,
-         max_y
-       )
-       when is_integer(max_x) and is_integer(max_y) do
+  defp viewport_bounds(border, max_x, max_y) do
     left = if border.left, do: 1, else: 0
     top = if border.top, do: 1, else: 0
 
     right = max(max_x - if(border.right, do: 1, else: 0), left)
     bottom = max(max_y - if(border.bottom, do: 1, else: 0), top)
 
-    viewport_height = bottom - top + 1
+    {left, top, right, bottom}
+  end
 
-    if viewport_height <= 0 or max_x < left or max_y < top do
+  defp resolve_visible_axes(
+         config,
+         content_width,
+         content_height,
+         viewport_width,
+         viewport_height
+       ) do
+    vertical? =
+      BackBreeze.Scrollbar.axis_enabled?(config, :vertical) and
+        BackBreeze.Scrollbar.visible?(config, :vertical, content_height, viewport_height)
+
+    horizontal? =
+      BackBreeze.Scrollbar.axis_enabled?(config, :horizontal) and
+        BackBreeze.Scrollbar.visible?(config, :horizontal, content_width, viewport_width)
+
+    {eff_viewport_width, eff_viewport_height} =
+      BackBreeze.Scrollbar.effective_viewport_size(
+        config,
+        viewport_width,
+        viewport_height,
+        vertical?,
+        horizontal?
+      )
+
+    vertical? =
+      BackBreeze.Scrollbar.axis_enabled?(config, :vertical) and
+        BackBreeze.Scrollbar.visible?(config, :vertical, content_height, eff_viewport_height)
+
+    horizontal? =
+      BackBreeze.Scrollbar.axis_enabled?(config, :horizontal) and
+        BackBreeze.Scrollbar.visible?(config, :horizontal, content_width, eff_viewport_width)
+
+    {eff_viewport_width, eff_viewport_height} =
+      BackBreeze.Scrollbar.effective_viewport_size(
+        config,
+        viewport_width,
+        viewport_height,
+        vertical?,
+        horizontal?
+      )
+
+    {vertical?, horizontal?, eff_viewport_width, eff_viewport_height}
+  end
+
+  defp normalize_scroll({top, left}) do
+    top = if is_integer(top), do: max(top, 0), else: 0
+    left = if is_integer(left), do: max(left, 0), else: 0
+    {top, left}
+  end
+
+  defp normalize_scroll(_), do: {0, 0}
+
+  defp trim_axis_for_intersection(start_pos, end_pos, other_enabled?, other_placement) do
+    start_pos = if other_enabled? && other_placement == :start, do: start_pos + 1, else: start_pos
+    end_pos = if other_enabled? && other_placement == :end, do: end_pos - 1, else: end_pos
+
+    {start_pos, max(start_pos - 1, end_pos)}
+  end
+
+  defp clear_vertical_strip(layer_map, x, y_start, y_end) when y_start <= y_end do
+    Enum.reduce(y_start..y_end, layer_map, fn y, acc ->
+      Map.put(acc, {y, x}, {" ", ""})
+    end)
+  end
+
+  defp clear_vertical_strip(layer_map, _x, _y_start, _y_end), do: layer_map
+
+  defp clear_horizontal_strip(layer_map, y, x_start, x_end) when x_start <= x_end do
+    Enum.reduce(x_start..x_end, layer_map, fn x, acc ->
+      Map.put(acc, {y, x}, {" ", ""})
+    end)
+  end
+
+  defp clear_horizontal_strip(layer_map, _y, _x_start, _x_end), do: layer_map
+
+  defp draw_vertical_scrollbar(
+         layer_map,
+         config,
+         x,
+         y_start,
+         y_end,
+         scroll_top,
+         content_height,
+         viewport_height
+       ) do
+    total_size = y_end - y_start + 1
+
+    if total_size <= 0 do
       layer_map
     else
-      content_height = max(dimensions.content_height, viewport_height)
-      max_scroll = max(content_height - viewport_height, 0)
-      scroll_top = if is_integer(scroll_top), do: scroll_top, else: 0
-      scroll_top = min(max(scroll_top, 0), max_scroll)
+      {track_start, track_end, layer_map} =
+        maybe_draw_axis_arrows(
+          layer_map,
+          config.arrows,
+          total_size,
+          y_start,
+          y_end,
+          fn pos, acc -> put_segment(acc, {pos, x}, config.vertical.arrow_start) end,
+          fn pos, acc -> put_segment(acc, {pos, x}, config.vertical.arrow_end) end
+        )
 
-      thumb_height =
-        max(div(viewport_height * viewport_height, max(content_height, 1)), 1)
-        |> min(viewport_height)
+      draw_scroll_track_and_thumb(
+        layer_map,
+        :vertical,
+        config,
+        track_start,
+        track_end,
+        scroll_top,
+        content_height,
+        viewport_height,
+        fn pos, acc, segment -> put_segment(acc, {pos, x}, segment) end
+      )
+    end
+  end
 
-      thumb_top =
-        if max_scroll == 0 or viewport_height == thumb_height do
-          0
-        else
-          round(scroll_top * (viewport_height - thumb_height) / max_scroll)
-        end
+  defp draw_horizontal_scrollbar(
+         layer_map,
+         config,
+         y,
+         x_start,
+         x_end,
+         scroll_left,
+         content_width,
+         viewport_width
+       ) do
+    total_size = x_end - x_start + 1
 
-      track_range = top..bottom
-      thumb_range = (top + thumb_top)..(top + thumb_top + thumb_height - 1)
+    if total_size <= 0 do
+      layer_map
+    else
+      {track_start, track_end, layer_map} =
+        maybe_draw_axis_arrows(
+          layer_map,
+          config.arrows,
+          total_size,
+          x_start,
+          x_end,
+          fn pos, acc -> put_segment(acc, {y, pos}, config.horizontal.arrow_start) end,
+          fn pos, acc -> put_segment(acc, {y, pos}, config.horizontal.arrow_end) end
+        )
 
-      layer_map =
-        Enum.reduce(track_range, layer_map, fn y, acc ->
-          Map.put(acc, {y, right}, {"│", ""})
-        end)
+      draw_scroll_track_and_thumb(
+        layer_map,
+        :horizontal,
+        config,
+        track_start,
+        track_end,
+        scroll_left,
+        content_width,
+        viewport_width,
+        fn pos, acc, segment -> put_segment(acc, {y, pos}, segment) end
+      )
+    end
+  end
 
-      Enum.reduce(thumb_range, layer_map, fn y, acc ->
-        Map.put(acc, {y, right}, {"█", ""})
+  defp maybe_draw_axis_arrows(
+         layer_map,
+         true,
+         total_size,
+         start_pos,
+         end_pos,
+         draw_start,
+         draw_end
+       )
+       when total_size >= 3 do
+    layer_map = draw_start.(start_pos, layer_map)
+    layer_map = draw_end.(end_pos, layer_map)
+    {start_pos + 1, end_pos - 1, layer_map}
+  end
+
+  defp maybe_draw_axis_arrows(
+         layer_map,
+         _arrows,
+         _total_size,
+         start_pos,
+         end_pos,
+         _draw_start,
+         _draw_end
+       ) do
+    {start_pos, end_pos, layer_map}
+  end
+
+  defp draw_scroll_track_and_thumb(
+         layer_map,
+         axis,
+         config,
+         track_start,
+         track_end,
+         scroll_value,
+         content_size,
+         viewport_size,
+         put_fn
+       )
+       when track_start <= track_end and viewport_size > 0 do
+    track_size = track_end - track_start + 1
+
+    {track_segment, thumb_segment} =
+      case axis do
+        :vertical -> {config.vertical.track, config.vertical.thumb}
+        :horizontal -> {config.horizontal.track, config.horizontal.thumb}
+      end
+
+    max_scroll = max(content_size - viewport_size, 0)
+    scroll_value = min(max(scroll_value, 0), max_scroll)
+
+    thumb_size =
+      BackBreeze.Scrollbar.thumb_size(config, track_size, max(content_size, viewport_size))
+
+    thumb_start =
+      if max_scroll == 0 or thumb_size >= track_size do
+        track_start
+      else
+        offset = round(scroll_value * (track_size - thumb_size) / max_scroll)
+        track_start + offset
+      end
+
+    thumb_end = min(thumb_start + thumb_size - 1, track_end)
+
+    layer_map =
+      Enum.reduce(track_start..track_end, layer_map, fn pos, acc ->
+        put_fn.(pos, acc, track_segment)
       end)
+
+    Enum.reduce(thumb_start..thumb_end, layer_map, fn pos, acc ->
+      put_fn.(pos, acc, thumb_segment)
+    end)
+  end
+
+  defp draw_scroll_track_and_thumb(
+         layer_map,
+         _axis,
+         _config,
+         _track_start,
+         _track_end,
+         _scroll_value,
+         _content_size,
+         _viewport_size,
+         _put_fn
+       ),
+       do: layer_map
+
+  defp maybe_draw_intersection(layer_map, config, true, true, x, y) do
+    put_segment(layer_map, {y, x}, config.intersection)
+  end
+
+  defp maybe_draw_intersection(layer_map, _config, _vertical?, _horizontal?, _x, _y),
+    do: layer_map
+
+  defp put_segment(layer_map, _point, nil), do: layer_map
+
+  defp put_segment(layer_map, point, segment) do
+    char = BackBreeze.Scrollbar.segment_char(segment)
+
+    if is_binary(char) do
+      Map.put(layer_map, point, {char, BackBreeze.Scrollbar.style_sequence(segment)})
+    else
+      layer_map
     end
   end
 
@@ -537,6 +846,15 @@ defmodule BackBreeze.Box do
 
     {x + width, y, {map, false, seq}}
   end
+
+  defp raw_content_width(content) when is_binary(content) do
+    content
+    |> String.split("\n")
+    |> Enum.map(&BackBreeze.Utils.string_length/1)
+    |> Enum.max(fn -> 0 end)
+  end
+
+  defp raw_content_width(_), do: 0
 
   defp set_layer([], result, _layer) do
     Enum.reverse(result)

--- a/lib/back_breeze/box.ex
+++ b/lib/back_breeze/box.ex
@@ -83,7 +83,36 @@ defmodule BackBreeze.Box do
 
   defp render_and_calc(%{box: %{children: []} = box} = acc, opts) do
     {content, dimensions, width} = render_self(box, opts)
-    box = %{box | content: content, width: width, state: :rendered, children: []}
+
+    {content, width, layer_map} =
+      if vertical_scrollbar?(box.style, dimensions) do
+        {layer_map, max_width, max_height} = generate_layer_map(content, %{}, 0, 0)
+
+        layer_map =
+          maybe_add_scrollbars(
+            layer_map,
+            box.style,
+            box.scroll,
+            dimensions,
+            max_width,
+            max_height
+          )
+
+        {layer_maps_to_content(layer_map, %{}, 0, 0, max_width, max_height), max_width + 1,
+         layer_map}
+      else
+        {content, width, %{}}
+      end
+
+    box = %{
+      box
+      | content: content,
+        width: width,
+        state: :rendered,
+        children: [],
+        layer_map: layer_map
+    }
+
     %{acc | box: box, dimensions: [{acc.id, dimensions} | acc.dimensions], id: acc.id + 1}
   end
 
@@ -116,13 +145,17 @@ defmodule BackBreeze.Box do
       render_self(%{box | width: width, height: height, style: style, scroll: {0, 0}}, opts)
 
     border_rows =
-      (if box.style.border.top, do: 1, else: 0) +
-        (if box.style.border.bottom, do: 1, else: 0)
+      if(box.style.border.top, do: 1, else: 0) +
+        if box.style.border.bottom, do: 1, else: 0
 
     dimensions =
       Enum.take(acc.dimensions, child_length)
       |> Enum.reduce(
-        %{content_height: 0, viewport_height: dimensions.height - border_rows, height: dimensions.height},
+        %{
+          content_height: 0,
+          viewport_height: dimensions.height - border_rows,
+          height: dimensions.height
+        },
         fn {_, dims}, acc ->
           %{acc | content_height: dims.height + acc.content_height}
         end
@@ -150,7 +183,15 @@ defmodule BackBreeze.Box do
         {max(max_width, child_width), max(max_height, child_height)}
       end
 
-    reset = Termite.Style.reset_code()
+    child_layer_map =
+      maybe_add_scrollbars(
+        child_layer_map,
+        box.style,
+        box.scroll,
+        dimensions,
+        max_width,
+        max_height
+      )
 
     {start_x, start_y} =
       case box do
@@ -158,45 +199,8 @@ defmodule BackBreeze.Box do
         _ -> {0, 0}
       end
 
-    y_range = start_y..max_height
-    x_range = start_x..max_width
-
     content =
-      Enum.map(y_range, fn y ->
-        {content, buffer, style, _} =
-          Enum.reduce(x_range, {"", "", "", false}, fn x, {acc, buffer, last_style, skip} ->
-            child_point = Map.get(child_layer_map, {y, x})
-
-            point =
-              if skip do
-                child_point
-              else
-                child_point || Map.get(layer_map, {y, x})
-              end
-
-            skip_next =
-              case child_point do
-                {char, _} -> Ucwidth.width(char) == 2
-                _ -> false
-              end
-
-            case {point, buffer, last_style} do
-              {nil, _, _} -> {acc, buffer, last_style, skip_next}
-              {{char, style}, _, style} -> {acc, buffer <> char, style, skip_next}
-              {{char, style}, _, ""} -> {acc <> buffer, char, style, skip_next}
-              {{char, style}, _, last} -> {acc <> last <> buffer <> reset, char, style, skip_next}
-            end
-          end)
-
-        case {buffer, style} do
-          {"", _} -> content
-          {_, nil} -> content <> buffer
-          {_, ""} -> content <> buffer
-          {_, style} -> content <> style <> buffer <> reset
-        end
-      end)
-
-    content = Enum.join(content, "\n") |> String.trim_trailing("\n")
+      layer_maps_to_content(layer_map, child_layer_map, start_x, start_y, max_width, max_height)
 
     box = %{
       box
@@ -381,6 +385,118 @@ defmodule BackBreeze.Box do
     {max_x, map} = Map.pop(acc, :max_x, 1)
 
     {map, max_x - 1, y}
+  end
+
+  defp layer_maps_to_content(layer_map, overlay_layer_map, start_x, start_y, max_x, max_y) do
+    reset = Termite.Style.reset_code()
+    y_range = start_y..max_y
+    x_range = start_x..max_x
+
+    content =
+      Enum.map(y_range, fn y ->
+        {content, buffer, style, _} =
+          Enum.reduce(x_range, {"", "", "", false}, fn x, {acc, buffer, last_style, skip} ->
+            overlay_point = Map.get(overlay_layer_map, {y, x})
+
+            point =
+              if skip do
+                overlay_point
+              else
+                overlay_point || Map.get(layer_map, {y, x})
+              end
+
+            skip_next =
+              case overlay_point do
+                {char, _} -> Ucwidth.width(char) == 2
+                _ -> false
+              end
+
+            case {point, buffer, last_style} do
+              {nil, _, _} -> {acc, buffer, last_style, skip_next}
+              {{char, style}, _, style} -> {acc, buffer <> char, style, skip_next}
+              {{char, style}, _, ""} -> {acc <> buffer, char, style, skip_next}
+              {{char, style}, _, last} -> {acc <> last <> buffer <> reset, char, style, skip_next}
+            end
+          end)
+
+        case {buffer, style} do
+          {"", _} -> content
+          {_, nil} -> content <> buffer
+          {_, ""} -> content <> buffer
+          {_, style} -> content <> style <> buffer <> reset
+        end
+      end)
+
+    Enum.join(content, "\n") |> String.trim_trailing("\n")
+  end
+
+  defp maybe_add_scrollbars(layer_map, style, scroll, dimensions, max_x, max_y) do
+    if vertical_scrollbar?(style, dimensions) do
+      add_vertical_scrollbar(layer_map, style, scroll, dimensions, max_x, max_y)
+    else
+      layer_map
+    end
+  end
+
+  defp vertical_scrollbar?(
+         %{overflow: :hidden, scrollbar: scrollbar},
+         %{content_height: content_height, viewport_height: viewport_height}
+       )
+       when scrollbar in [true, :vertical, :both] and is_integer(content_height) and
+              is_integer(viewport_height) do
+    content_height > viewport_height and viewport_height > 0
+  end
+
+  defp vertical_scrollbar?(_style, _dimensions), do: false
+
+  defp add_vertical_scrollbar(
+         layer_map,
+         %{border: border},
+         {scroll_top, _},
+         dimensions,
+         max_x,
+         max_y
+       )
+       when is_integer(max_x) and is_integer(max_y) do
+    left = if border.left, do: 1, else: 0
+    top = if border.top, do: 1, else: 0
+
+    right = max(max_x - if(border.right, do: 1, else: 0), left)
+    bottom = max(max_y - if(border.bottom, do: 1, else: 0), top)
+
+    viewport_height = bottom - top + 1
+
+    if viewport_height <= 0 or max_x < left or max_y < top do
+      layer_map
+    else
+      content_height = max(dimensions.content_height, viewport_height)
+      max_scroll = max(content_height - viewport_height, 0)
+      scroll_top = if is_integer(scroll_top), do: scroll_top, else: 0
+      scroll_top = min(max(scroll_top, 0), max_scroll)
+
+      thumb_height =
+        max(div(viewport_height * viewport_height, max(content_height, 1)), 1)
+        |> min(viewport_height)
+
+      thumb_top =
+        if max_scroll == 0 or viewport_height == thumb_height do
+          0
+        else
+          round(scroll_top * (viewport_height - thumb_height) / max_scroll)
+        end
+
+      track_range = top..bottom
+      thumb_range = (top + thumb_top)..(top + thumb_top + thumb_height - 1)
+
+      layer_map =
+        Enum.reduce(track_range, layer_map, fn y, acc ->
+          Map.put(acc, {y, right}, {"│", ""})
+        end)
+
+      Enum.reduce(thumb_range, layer_map, fn y, acc ->
+        Map.put(acc, {y, right}, {"█", ""})
+      end)
+    end
   end
 
   defp clip_child_layer_map(layer_map, %{overflow: :hidden, border: border}, max_x, max_y)

--- a/lib/back_breeze/box.ex
+++ b/lib/back_breeze/box.ex
@@ -6,6 +6,52 @@ defmodule BackBreeze.Box do
   """
   alias BackBreeze.Ucwidth
 
+  defmodule ScrollbarContext do
+    @moduledoc false
+
+    defstruct style: %BackBreeze.Style{},
+              config: %BackBreeze.Scrollbar{},
+              scroll: {0, 0},
+              metrics: %{},
+              max_x: 0,
+              max_y: 0,
+              left: 0,
+              top: 0,
+              right: 0,
+              bottom: 0,
+              viewport_width: 0,
+              viewport_height: 0,
+              content_width: 0,
+              content_height: 0,
+              vertical?: false,
+              horizontal?: false,
+              eff_viewport_width: 0,
+              eff_viewport_height: 0,
+              vertical_placement: :end,
+              horizontal_placement: :end,
+              x_scrollbar: 0,
+              y_scrollbar: 0,
+              vertical_start: 0,
+              vertical_end: -1,
+              horizontal_start: 0,
+              horizontal_end: -1,
+              scroll_top: 0,
+              scroll_left: 0
+  end
+
+  defmodule AxisContext do
+    @moduledoc false
+
+    defstruct axis: :vertical,
+              config: %BackBreeze.Scrollbar{},
+              fixed: 0,
+              start: 0,
+              stop: -1,
+              scroll_value: 0,
+              content_size: 0,
+              viewport_size: 0
+  end
+
   defstruct content: "",
             children: [],
             style: %BackBreeze.Style{},
@@ -91,20 +137,23 @@ defmodule BackBreeze.Box do
         {layer_map, max_width, max_height} = generate_layer_map(content, %{}, 0, 0)
 
         layer_map =
-          maybe_add_scrollbars(
-            layer_map,
-            box.style,
-            box.scroll,
-            %{
+          maybe_add_scrollbars(layer_map, %{
+            style: box.style,
+            scroll: box.scroll,
+            metrics: %{
               content_height: dimensions.content_height,
               content_width: raw_content_width(box.content)
             },
-            max_width,
-            max_height
-          )
+            max_x: max_width,
+            max_y: max_height
+          })
 
-        {layer_maps_to_content(layer_map, %{}, 0, 0, max_width, max_height), max_width + 1,
-         layer_map}
+        {layer_maps_to_content(layer_map, %{}, %{
+           start_x: 0,
+           start_y: 0,
+           max_x: max_width,
+           max_y: max_height
+         }), max_width + 1, layer_map}
       else
         {content, width, %{}}
       end
@@ -189,14 +238,13 @@ defmodule BackBreeze.Box do
       end
 
     child_layer_map =
-      maybe_add_scrollbars(
-        child_layer_map,
-        box.style,
-        box.scroll,
-        %{content_height: dimensions.content_height, content_width: child_width},
-        max_width,
-        max_height
-      )
+      maybe_add_scrollbars(child_layer_map, %{
+        style: box.style,
+        scroll: box.scroll,
+        metrics: %{content_height: dimensions.content_height, content_width: child_width},
+        max_x: max_width,
+        max_y: max_height
+      })
 
     {start_x, start_y} =
       case box do
@@ -205,7 +253,12 @@ defmodule BackBreeze.Box do
       end
 
     content =
-      layer_maps_to_content(layer_map, child_layer_map, start_x, start_y, max_width, max_height)
+      layer_maps_to_content(layer_map, child_layer_map, %{
+        start_x: start_x,
+        start_y: start_y,
+        max_x: max_width,
+        max_y: max_height
+      })
 
     box = %{
       box
@@ -392,15 +445,19 @@ defmodule BackBreeze.Box do
     {map, max_x - 1, y}
   end
 
-  defp layer_maps_to_content(layer_map, overlay_layer_map, start_x, start_y, max_x, max_y) do
+  defp layer_maps_to_content(layer_map, overlay_layer_map, %{
+         start_x: start_x,
+         start_y: start_y,
+         max_x: max_x,
+         max_y: max_y
+       }) do
     reset = Termite.Style.reset_code()
-    y_range = start_y..max_y
-    x_range = start_x..max_x
 
     content =
-      Enum.map(y_range, fn y ->
+      Enum.map(start_y..max_y, fn y ->
         {content, buffer, style, _} =
-          Enum.reduce(x_range, {"", "", "", false}, fn x, {acc, buffer, last_style, skip} ->
+          Enum.reduce(start_x..max_x, {"", "", "", false}, fn x,
+                                                              {acc, buffer, last_style, skip} ->
             overlay_point = Map.get(overlay_layer_map, {y, x})
 
             point =
@@ -435,119 +492,157 @@ defmodule BackBreeze.Box do
     Enum.join(content, "\n") |> String.trim_trailing("\n")
   end
 
-  defp maybe_add_scrollbars(layer_map, style, scroll, metrics, max_x, max_y) do
-    config = BackBreeze.Scrollbar.normalize(style.scrollbar, style)
+  defp maybe_add_scrollbars(layer_map, options)
+       when is_map(options) and not is_struct(options, ScrollbarContext) do
+    options
+    |> build_scrollbar_context()
+    |> then(&maybe_add_scrollbars(layer_map, &1))
+  end
 
+  defp maybe_add_scrollbars(layer_map, %ScrollbarContext{} = context) do
     cond do
-      style.overflow != :hidden or !config.enabled ->
+      context.style.overflow != :hidden or !context.config.enabled ->
         layer_map
 
-      !is_integer(max_x) or !is_integer(max_y) ->
+      !is_integer(context.max_x) or !is_integer(context.max_y) ->
         layer_map
 
       true ->
-        {left, top, right, bottom} = viewport_bounds(style.border, max_x, max_y)
+        context = prepare_scrollbar_context(context)
 
-        viewport_width = max(right - left + 1, 0)
-        viewport_height = max(bottom - top + 1, 0)
-
-        content_height = max(Map.get(metrics, :content_height, viewport_height), viewport_height)
-        content_width = max(Map.get(metrics, :content_width, viewport_width), viewport_width)
-
-        {vertical?, horizontal?, eff_viewport_width, eff_viewport_height} =
-          resolve_visible_axes(
-            config,
-            content_width,
-            content_height,
-            viewport_width,
-            viewport_height
-          )
-
-        if !vertical? and !horizontal? do
+        if !context.vertical? and !context.horizontal? do
           layer_map
         else
-          vertical_placement = BackBreeze.Scrollbar.placement(config, :vertical)
-          horizontal_placement = BackBreeze.Scrollbar.placement(config, :horizontal)
-
-          {x_scrollbar, y_scrollbar} =
-            scrollbar_positions(
-              style.border,
-              config,
-              left,
-              top,
-              right,
-              bottom,
-              vertical_placement,
-              horizontal_placement
-            )
-
-          {vertical_start, vertical_end} =
-            trim_axis_for_intersection(top, bottom, horizontal?, horizontal_placement)
-
-          {horizontal_start, horizontal_end} =
-            trim_axis_for_intersection(left, right, vertical?, vertical_placement)
-
-          layer_map =
-            if config.mode == :inset and vertical? and x_scrollbar >= left and
-                 x_scrollbar <= right do
-              clear_vertical_strip(layer_map, x_scrollbar, vertical_start, vertical_end)
-            else
-              layer_map
-            end
-
-          layer_map =
-            if config.mode == :inset and horizontal? and y_scrollbar >= top and
-                 y_scrollbar <= bottom do
-              clear_horizontal_strip(layer_map, y_scrollbar, horizontal_start, horizontal_end)
-            else
-              layer_map
-            end
-
-          {scroll_top, scroll_left} = normalize_scroll(scroll)
-
-          layer_map =
-            if vertical? do
-              draw_vertical_scrollbar(
-                layer_map,
-                config,
-                x_scrollbar,
-                vertical_start,
-                vertical_end,
-                scroll_top,
-                content_height,
-                eff_viewport_height
-              )
-            else
-              layer_map
-            end
-
-          layer_map =
-            if horizontal? do
-              draw_horizontal_scrollbar(
-                layer_map,
-                config,
-                y_scrollbar,
-                horizontal_start,
-                horizontal_end,
-                scroll_left,
-                content_width,
-                eff_viewport_width
-              )
-            else
-              layer_map
-            end
-
-          maybe_draw_intersection(
-            layer_map,
-            config,
-            vertical?,
-            horizontal?,
-            x_scrollbar,
-            y_scrollbar
-          )
+          layer_map
+          |> maybe_clear_scrollbar_strips(context)
+          |> maybe_draw_vertical_scrollbar(context)
+          |> maybe_draw_horizontal_scrollbar(context)
+          |> maybe_draw_intersection(context)
         end
     end
   end
+
+  defp build_scrollbar_context(%{style: style} = options) do
+    %ScrollbarContext{
+      style: style,
+      config: BackBreeze.Scrollbar.normalize(style.scrollbar, style),
+      scroll: Map.get(options, :scroll, {0, 0}),
+      metrics: Map.get(options, :metrics, %{}),
+      max_x: Map.get(options, :max_x),
+      max_y: Map.get(options, :max_y)
+    }
+  end
+
+  defp prepare_scrollbar_context(%ScrollbarContext{} = context) do
+    {left, top, right, bottom} =
+      viewport_bounds(context.style.border, context.max_x, context.max_y)
+
+    viewport_width = max(right - left + 1, 0)
+    viewport_height = max(bottom - top + 1, 0)
+
+    metrics = if is_map(context.metrics), do: context.metrics, else: %{}
+
+    content_height = max(Map.get(metrics, :content_height, viewport_height), viewport_height)
+    content_width = max(Map.get(metrics, :content_width, viewport_width), viewport_width)
+
+    %{
+      context
+      | left: left,
+        top: top,
+        right: right,
+        bottom: bottom,
+        viewport_width: viewport_width,
+        viewport_height: viewport_height,
+        content_width: content_width,
+        content_height: content_height
+    }
+    |> resolve_visible_axes()
+    |> set_scrollbar_positions()
+    |> set_scroll_offsets()
+  end
+
+  defp set_scrollbar_positions(%ScrollbarContext{} = context) do
+    vertical_placement = BackBreeze.Scrollbar.placement(context.config, :vertical)
+    horizontal_placement = BackBreeze.Scrollbar.placement(context.config, :horizontal)
+
+    {x_scrollbar, y_scrollbar} =
+      scrollbar_positions(context, vertical_placement, horizontal_placement)
+
+    {vertical_start, vertical_end} =
+      trim_axis_for_intersection(
+        context.top,
+        context.bottom,
+        context.horizontal?,
+        horizontal_placement
+      )
+
+    {horizontal_start, horizontal_end} =
+      trim_axis_for_intersection(
+        context.left,
+        context.right,
+        context.vertical?,
+        vertical_placement
+      )
+
+    %{
+      context
+      | vertical_placement: vertical_placement,
+        horizontal_placement: horizontal_placement,
+        x_scrollbar: x_scrollbar,
+        y_scrollbar: y_scrollbar,
+        vertical_start: vertical_start,
+        vertical_end: vertical_end,
+        horizontal_start: horizontal_start,
+        horizontal_end: horizontal_end
+    }
+  end
+
+  defp set_scroll_offsets(%ScrollbarContext{} = context) do
+    {scroll_top, scroll_left} = normalize_scroll(context.scroll)
+    %{context | scroll_top: scroll_top, scroll_left: scroll_left}
+  end
+
+  defp maybe_clear_scrollbar_strips(layer_map, context) do
+    layer_map
+    |> maybe_clear_vertical_scrollbar_strip(context)
+    |> maybe_clear_horizontal_scrollbar_strip(context)
+  end
+
+  defp maybe_clear_vertical_scrollbar_strip(
+         layer_map,
+         %ScrollbarContext{
+           config: %{mode: :inset},
+           vertical?: true,
+           x_scrollbar: x_scrollbar,
+           left: left,
+           right: right,
+           vertical_start: vertical_start,
+           vertical_end: vertical_end
+         }
+       )
+       when x_scrollbar >= left and x_scrollbar <= right do
+    clear_vertical_strip(layer_map, x_scrollbar, vertical_start, vertical_end)
+  end
+
+  defp maybe_clear_vertical_scrollbar_strip(layer_map, _context), do: layer_map
+
+  defp maybe_clear_horizontal_scrollbar_strip(
+         layer_map,
+         %ScrollbarContext{
+           config: %{mode: :inset},
+           horizontal?: true,
+           y_scrollbar: y_scrollbar,
+           top: top,
+           bottom: bottom,
+           horizontal_start: horizontal_start,
+           horizontal_end: horizontal_end
+         }
+       )
+       when y_scrollbar >= top and y_scrollbar <= bottom do
+    clear_horizontal_strip(layer_map, y_scrollbar, horizontal_start, horizontal_end)
+  end
+
+  defp maybe_clear_horizontal_scrollbar_strip(layer_map, _context), do: layer_map
 
   defp viewport_bounds(border, max_x, max_y) do
     left = if border.left, do: 1, else: 0
@@ -560,12 +655,14 @@ defmodule BackBreeze.Box do
   end
 
   defp scrollbar_positions(
-         border,
-         config,
-         left,
-         top,
-         right,
-         bottom,
+         %ScrollbarContext{
+           style: %{border: border},
+           config: config,
+           left: left,
+           top: top,
+           right: right,
+           bottom: bottom
+         },
          vertical_placement,
          horizontal_placement
        ) do
@@ -588,48 +685,68 @@ defmodule BackBreeze.Box do
     {x_scrollbar, y_scrollbar}
   end
 
-  defp resolve_visible_axes(
-         config,
-         content_width,
-         content_height,
-         viewport_width,
-         viewport_height
-       ) do
-    vertical? =
-      BackBreeze.Scrollbar.axis_enabled?(config, :vertical) and
-        BackBreeze.Scrollbar.visible?(config, :vertical, content_height, viewport_height)
-
-    horizontal? =
-      BackBreeze.Scrollbar.axis_enabled?(config, :horizontal) and
-        BackBreeze.Scrollbar.visible?(config, :horizontal, content_width, viewport_width)
-
-    {eff_viewport_width, eff_viewport_height} =
-      BackBreeze.Scrollbar.effective_viewport_size(
-        config,
-        viewport_width,
-        viewport_height,
-        vertical?,
-        horizontal?
-      )
+  defp resolve_visible_axes(%ScrollbarContext{} = context) do
+    config = context.config
 
     vertical? =
       BackBreeze.Scrollbar.axis_enabled?(config, :vertical) and
-        BackBreeze.Scrollbar.visible?(config, :vertical, content_height, eff_viewport_height)
+        BackBreeze.Scrollbar.visible?(
+          config,
+          :vertical,
+          context.content_height,
+          context.viewport_height
+        )
 
     horizontal? =
       BackBreeze.Scrollbar.axis_enabled?(config, :horizontal) and
-        BackBreeze.Scrollbar.visible?(config, :horizontal, content_width, eff_viewport_width)
+        BackBreeze.Scrollbar.visible?(
+          config,
+          :horizontal,
+          context.content_width,
+          context.viewport_width
+        )
 
     {eff_viewport_width, eff_viewport_height} =
-      BackBreeze.Scrollbar.effective_viewport_size(
-        config,
-        viewport_width,
-        viewport_height,
-        vertical?,
-        horizontal?
-      )
+      BackBreeze.Scrollbar.effective_viewport_size(config, %{
+        width: context.viewport_width,
+        height: context.viewport_height,
+        vertical?: vertical?,
+        horizontal?: horizontal?
+      })
 
-    {vertical?, horizontal?, eff_viewport_width, eff_viewport_height}
+    vertical? =
+      BackBreeze.Scrollbar.axis_enabled?(config, :vertical) and
+        BackBreeze.Scrollbar.visible?(
+          config,
+          :vertical,
+          context.content_height,
+          eff_viewport_height
+        )
+
+    horizontal? =
+      BackBreeze.Scrollbar.axis_enabled?(config, :horizontal) and
+        BackBreeze.Scrollbar.visible?(
+          config,
+          :horizontal,
+          context.content_width,
+          eff_viewport_width
+        )
+
+    {eff_viewport_width, eff_viewport_height} =
+      BackBreeze.Scrollbar.effective_viewport_size(config, %{
+        width: context.viewport_width,
+        height: context.viewport_height,
+        vertical?: vertical?,
+        horizontal?: horizontal?
+      })
+
+    %{
+      context
+      | vertical?: vertical?,
+        horizontal?: horizontal?,
+        eff_viewport_width: eff_viewport_width,
+        eff_viewport_height: eff_viewport_height
+    }
   end
 
   defp normalize_scroll({top, left}) do
@@ -663,138 +780,116 @@ defmodule BackBreeze.Box do
 
   defp clear_horizontal_strip(layer_map, _y, _x_start, _x_end), do: layer_map
 
-  defp draw_vertical_scrollbar(
-         layer_map,
-         config,
-         x,
-         y_start,
-         y_end,
-         scroll_top,
-         content_height,
-         viewport_height
-       ) do
-    total_size = y_end - y_start + 1
-
-    if total_size <= 0 do
-      layer_map
-    else
-      {track_start, track_end, layer_map} =
-        maybe_draw_axis_arrows(
-          layer_map,
-          config.arrows,
-          total_size,
-          y_start,
-          y_end,
-          fn pos, acc -> put_segment(acc, {pos, x}, config.vertical.arrow_start) end,
-          fn pos, acc -> put_segment(acc, {pos, x}, config.vertical.arrow_end) end
-        )
-
-      draw_scroll_track_and_thumb(
-        layer_map,
-        :vertical,
-        config,
-        track_start,
-        track_end,
-        scroll_top,
-        content_height,
-        viewport_height,
-        fn pos, acc, segment -> put_segment(acc, {pos, x}, segment) end
-      )
-    end
+  defp maybe_draw_vertical_scrollbar(layer_map, %ScrollbarContext{vertical?: true} = context) do
+    context
+    |> vertical_axis_context()
+    |> then(&draw_axis_scrollbar(layer_map, &1))
   end
 
-  defp draw_horizontal_scrollbar(
+  defp maybe_draw_vertical_scrollbar(layer_map, _context), do: layer_map
+
+  defp maybe_draw_horizontal_scrollbar(
          layer_map,
-         config,
-         y,
-         x_start,
-         x_end,
-         scroll_left,
-         content_width,
-         viewport_width
+         %ScrollbarContext{horizontal?: true} = context
        ) do
-    total_size = x_end - x_start + 1
+    context
+    |> horizontal_axis_context()
+    |> then(&draw_axis_scrollbar(layer_map, &1))
+  end
+
+  defp maybe_draw_horizontal_scrollbar(layer_map, _context), do: layer_map
+
+  defp vertical_axis_context(%ScrollbarContext{} = context) do
+    %AxisContext{
+      axis: :vertical,
+      config: context.config,
+      fixed: context.x_scrollbar,
+      start: context.vertical_start,
+      stop: context.vertical_end,
+      scroll_value: context.scroll_top,
+      content_size: context.content_height,
+      viewport_size: context.eff_viewport_height
+    }
+  end
+
+  defp horizontal_axis_context(%ScrollbarContext{} = context) do
+    %AxisContext{
+      axis: :horizontal,
+      config: context.config,
+      fixed: context.y_scrollbar,
+      start: context.horizontal_start,
+      stop: context.horizontal_end,
+      scroll_value: context.scroll_left,
+      content_size: context.content_width,
+      viewport_size: context.eff_viewport_width
+    }
+  end
+
+  defp draw_axis_scrollbar(layer_map, %AxisContext{} = axis_context) do
+    total_size = axis_context.stop - axis_context.start + 1
 
     if total_size <= 0 do
       layer_map
     else
       {track_start, track_end, layer_map} =
-        maybe_draw_axis_arrows(
-          layer_map,
-          config.arrows,
-          total_size,
-          x_start,
-          x_end,
-          fn pos, acc -> put_segment(acc, {y, pos}, config.horizontal.arrow_start) end,
-          fn pos, acc -> put_segment(acc, {y, pos}, config.horizontal.arrow_end) end
-        )
+        maybe_draw_axis_arrows(layer_map, axis_context, total_size)
 
-      draw_scroll_track_and_thumb(
-        layer_map,
-        :horizontal,
-        config,
-        track_start,
-        track_end,
-        scroll_left,
-        content_width,
-        viewport_width,
-        fn pos, acc, segment -> put_segment(acc, {y, pos}, segment) end
-      )
+      draw_scroll_track_and_thumb(layer_map, %{
+        axis_context
+        | start: track_start,
+          stop: track_end
+      })
     end
   end
 
   defp maybe_draw_axis_arrows(
          layer_map,
-         true,
-         total_size,
-         start_pos,
-         end_pos,
-         draw_start,
-         draw_end
+         %AxisContext{config: %{arrows: true}} = axis_context,
+         total_size
        )
        when total_size >= 3 do
-    layer_map = draw_start.(start_pos, layer_map)
-    layer_map = draw_end.(end_pos, layer_map)
-    {start_pos + 1, end_pos - 1, layer_map}
+    layer_map =
+      put_axis_segment(
+        layer_map,
+        axis_context,
+        axis_context.start,
+        axis_arrow_segment(axis_context, :start)
+      )
+
+    layer_map =
+      put_axis_segment(
+        layer_map,
+        axis_context,
+        axis_context.stop,
+        axis_arrow_segment(axis_context, :end)
+      )
+
+    {axis_context.start + 1, axis_context.stop - 1, layer_map}
   end
 
-  defp maybe_draw_axis_arrows(
-         layer_map,
-         _arrows,
-         _total_size,
-         start_pos,
-         end_pos,
-         _draw_start,
-         _draw_end
-       ) do
-    {start_pos, end_pos, layer_map}
+  defp maybe_draw_axis_arrows(layer_map, %AxisContext{} = axis_context, _total_size) do
+    {axis_context.start, axis_context.stop, layer_map}
   end
 
   defp draw_scroll_track_and_thumb(
          layer_map,
-         axis,
-         config,
-         track_start,
-         track_end,
-         scroll_value,
-         content_size,
-         viewport_size,
-         put_fn
+         %AxisContext{start: track_start, stop: track_end, viewport_size: viewport_size} =
+           axis_context
        )
        when track_start <= track_end and viewport_size > 0 do
     track_size = track_end - track_start + 1
 
-    {track_segment, thumb_segment} =
-      case axis do
-        :vertical -> {config.vertical.track, config.vertical.thumb}
-        :horizontal -> {config.horizontal.track, config.horizontal.thumb}
-      end
+    {track_segment, thumb_segment} = axis_segments(axis_context)
 
-    max_scroll = max(content_size - viewport_size, 0)
-    scroll_value = min(max(scroll_value, 0), max_scroll)
+    max_scroll = max(axis_context.content_size - axis_context.viewport_size, 0)
+    scroll_value = min(max(axis_context.scroll_value, 0), max_scroll)
 
     thumb_size =
-      BackBreeze.Scrollbar.thumb_size(config, track_size, max(content_size, viewport_size))
+      BackBreeze.Scrollbar.thumb_size(
+        axis_context.config,
+        track_size,
+        max(axis_context.content_size, axis_context.viewport_size)
+      )
 
     thumb_start =
       if max_scroll == 0 or thumb_size >= track_size do
@@ -808,33 +903,55 @@ defmodule BackBreeze.Box do
 
     layer_map =
       Enum.reduce(track_start..track_end, layer_map, fn pos, acc ->
-        put_fn.(pos, acc, track_segment)
+        put_axis_segment(acc, axis_context, pos, track_segment)
       end)
 
     Enum.reduce(thumb_start..thumb_end, layer_map, fn pos, acc ->
-      put_fn.(pos, acc, thumb_segment)
+      put_axis_segment(acc, axis_context, pos, thumb_segment)
     end)
   end
 
-  defp draw_scroll_track_and_thumb(
-         layer_map,
-         _axis,
-         _config,
-         _track_start,
-         _track_end,
-         _scroll_value,
-         _content_size,
-         _viewport_size,
-         _put_fn
-       ),
-       do: layer_map
+  defp draw_scroll_track_and_thumb(layer_map, _axis_context), do: layer_map
 
-  defp maybe_draw_intersection(layer_map, config, true, true, x, y) do
-    put_segment(layer_map, {y, x}, config.intersection)
+  defp axis_segments(%AxisContext{axis: :vertical, config: config}) do
+    {config.vertical.track, config.vertical.thumb}
   end
 
-  defp maybe_draw_intersection(layer_map, _config, _vertical?, _horizontal?, _x, _y),
-    do: layer_map
+  defp axis_segments(%AxisContext{axis: :horizontal, config: config}) do
+    {config.horizontal.track, config.horizontal.thumb}
+  end
+
+  defp axis_arrow_segment(%AxisContext{axis: :vertical, config: config}, :start),
+    do: config.vertical.arrow_start
+
+  defp axis_arrow_segment(%AxisContext{axis: :vertical, config: config}, :end),
+    do: config.vertical.arrow_end
+
+  defp axis_arrow_segment(%AxisContext{axis: :horizontal, config: config}, :start),
+    do: config.horizontal.arrow_start
+
+  defp axis_arrow_segment(%AxisContext{axis: :horizontal, config: config}, :end),
+    do: config.horizontal.arrow_end
+
+  defp put_axis_segment(layer_map, %AxisContext{} = axis_context, pos, segment) do
+    put_segment(layer_map, axis_point(axis_context, pos), segment)
+  end
+
+  defp axis_point(%AxisContext{axis: :vertical, fixed: fixed}, pos), do: {pos, fixed}
+  defp axis_point(%AxisContext{axis: :horizontal, fixed: fixed}, pos), do: {fixed, pos}
+
+  defp maybe_draw_intersection(
+         layer_map,
+         %ScrollbarContext{vertical?: true, horizontal?: true} = context
+       ) do
+    put_segment(
+      layer_map,
+      {context.y_scrollbar, context.x_scrollbar},
+      context.config.intersection
+    )
+  end
+
+  defp maybe_draw_intersection(layer_map, _context), do: layer_map
 
   defp put_segment(layer_map, _point, nil), do: layer_map
 

--- a/lib/back_breeze/box.ex
+++ b/lib/back_breeze/box.ex
@@ -6,52 +6,6 @@ defmodule BackBreeze.Box do
   """
   alias BackBreeze.Ucwidth
 
-  defmodule ScrollbarContext do
-    @moduledoc false
-
-    defstruct style: %BackBreeze.Style{},
-              config: %BackBreeze.Scrollbar{},
-              scroll: {0, 0},
-              metrics: %{},
-              max_x: 0,
-              max_y: 0,
-              left: 0,
-              top: 0,
-              right: 0,
-              bottom: 0,
-              viewport_width: 0,
-              viewport_height: 0,
-              content_width: 0,
-              content_height: 0,
-              vertical?: false,
-              horizontal?: false,
-              eff_viewport_width: 0,
-              eff_viewport_height: 0,
-              vertical_placement: :end,
-              horizontal_placement: :end,
-              x_scrollbar: 0,
-              y_scrollbar: 0,
-              vertical_start: 0,
-              vertical_end: -1,
-              horizontal_start: 0,
-              horizontal_end: -1,
-              scroll_top: 0,
-              scroll_left: 0
-  end
-
-  defmodule AxisContext do
-    @moduledoc false
-
-    defstruct axis: :vertical,
-              config: %BackBreeze.Scrollbar{},
-              fixed: 0,
-              start: 0,
-              stop: -1,
-              scroll_value: 0,
-              content_size: 0,
-              viewport_size: 0
-  end
-
   defstruct content: "",
             children: [],
             style: %BackBreeze.Style{},
@@ -59,10 +13,10 @@ defmodule BackBreeze.Box do
             height: nil,
             state: :ready,
             position: :relative,
-            display: :block,
             left: nil,
-            scroll: {0, 0},
             top: nil,
+            display: :block,
+            scroll: {0, 0},
             layer: 0,
             layer_map: %{}
 
@@ -88,6 +42,7 @@ defmodule BackBreeze.Box do
       end
 
     style = struct(BackBreeze.Style, style)
+
     struct(BackBreeze.Box, Map.put(map, :style, style))
   end
 
@@ -137,13 +92,11 @@ defmodule BackBreeze.Box do
         {layer_map, max_width, max_height} = generate_layer_map(content, %{}, 0, 0)
 
         layer_map =
-          maybe_add_scrollbars(layer_map, %{
+          BackBreeze.Scrollbar.add_to_layer_map(layer_map, %{
             style: box.style,
             scroll: box.scroll,
-            metrics: %{
-              content_height: dimensions.content_height,
-              content_width: raw_content_width(box.content)
-            },
+            content_height: dimensions.content_height,
+            content_width: raw_content_width(box.content),
             max_x: max_width,
             max_y: max_height
           })
@@ -238,17 +191,18 @@ defmodule BackBreeze.Box do
       end
 
     child_layer_map =
-      maybe_add_scrollbars(child_layer_map, %{
+      BackBreeze.Scrollbar.add_to_layer_map(child_layer_map, %{
         style: box.style,
         scroll: box.scroll,
-        metrics: %{content_height: dimensions.content_height, content_width: child_width},
+        content_height: dimensions.content_height,
+        content_width: child_width,
         max_x: max_width,
         max_y: max_height
       })
 
     {start_x, start_y} =
-      case box do
-        %{position: :absolute, left: left, top: top} -> {left, top}
+      case box.position do
+        :absolute -> {box.left, box.top}
         _ -> {0, 0}
       end
 
@@ -490,479 +444,6 @@ defmodule BackBreeze.Box do
       end)
 
     Enum.join(content, "\n") |> String.trim_trailing("\n")
-  end
-
-  defp maybe_add_scrollbars(layer_map, options)
-       when is_map(options) and not is_struct(options, ScrollbarContext) do
-    options
-    |> build_scrollbar_context()
-    |> then(&maybe_add_scrollbars(layer_map, &1))
-  end
-
-  defp maybe_add_scrollbars(layer_map, %ScrollbarContext{} = context) do
-    cond do
-      context.style.overflow != :hidden or !context.config.enabled ->
-        layer_map
-
-      !is_integer(context.max_x) or !is_integer(context.max_y) ->
-        layer_map
-
-      true ->
-        context = prepare_scrollbar_context(context)
-
-        if !context.vertical? and !context.horizontal? do
-          layer_map
-        else
-          layer_map
-          |> maybe_clear_scrollbar_strips(context)
-          |> maybe_draw_vertical_scrollbar(context)
-          |> maybe_draw_horizontal_scrollbar(context)
-          |> maybe_draw_intersection(context)
-        end
-    end
-  end
-
-  defp build_scrollbar_context(%{style: style} = options) do
-    %ScrollbarContext{
-      style: style,
-      config: BackBreeze.Scrollbar.normalize(style.scrollbar, style),
-      scroll: Map.get(options, :scroll, {0, 0}),
-      metrics: Map.get(options, :metrics, %{}),
-      max_x: Map.get(options, :max_x),
-      max_y: Map.get(options, :max_y)
-    }
-  end
-
-  defp prepare_scrollbar_context(%ScrollbarContext{} = context) do
-    {left, top, right, bottom} =
-      viewport_bounds(context.style.border, context.max_x, context.max_y)
-
-    viewport_width = max(right - left + 1, 0)
-    viewport_height = max(bottom - top + 1, 0)
-
-    metrics = if is_map(context.metrics), do: context.metrics, else: %{}
-
-    content_height = max(Map.get(metrics, :content_height, viewport_height), viewport_height)
-    content_width = max(Map.get(metrics, :content_width, viewport_width), viewport_width)
-
-    %{
-      context
-      | left: left,
-        top: top,
-        right: right,
-        bottom: bottom,
-        viewport_width: viewport_width,
-        viewport_height: viewport_height,
-        content_width: content_width,
-        content_height: content_height
-    }
-    |> resolve_visible_axes()
-    |> set_scrollbar_positions()
-    |> set_scroll_offsets()
-  end
-
-  defp set_scrollbar_positions(%ScrollbarContext{} = context) do
-    vertical_placement = BackBreeze.Scrollbar.placement(context.config, :vertical)
-    horizontal_placement = BackBreeze.Scrollbar.placement(context.config, :horizontal)
-
-    {x_scrollbar, y_scrollbar} =
-      scrollbar_positions(context, vertical_placement, horizontal_placement)
-
-    {vertical_start, vertical_end} =
-      trim_axis_for_intersection(
-        context.top,
-        context.bottom,
-        context.horizontal?,
-        horizontal_placement
-      )
-
-    {horizontal_start, horizontal_end} =
-      trim_axis_for_intersection(
-        context.left,
-        context.right,
-        context.vertical?,
-        vertical_placement
-      )
-
-    %{
-      context
-      | vertical_placement: vertical_placement,
-        horizontal_placement: horizontal_placement,
-        x_scrollbar: x_scrollbar,
-        y_scrollbar: y_scrollbar,
-        vertical_start: vertical_start,
-        vertical_end: vertical_end,
-        horizontal_start: horizontal_start,
-        horizontal_end: horizontal_end
-    }
-  end
-
-  defp set_scroll_offsets(%ScrollbarContext{} = context) do
-    {scroll_top, scroll_left} = normalize_scroll(context.scroll)
-    %{context | scroll_top: scroll_top, scroll_left: scroll_left}
-  end
-
-  defp maybe_clear_scrollbar_strips(layer_map, context) do
-    layer_map
-    |> maybe_clear_vertical_scrollbar_strip(context)
-    |> maybe_clear_horizontal_scrollbar_strip(context)
-  end
-
-  defp maybe_clear_vertical_scrollbar_strip(
-         layer_map,
-         %ScrollbarContext{
-           config: %{mode: :inset},
-           vertical?: true,
-           x_scrollbar: x_scrollbar,
-           left: left,
-           right: right,
-           vertical_start: vertical_start,
-           vertical_end: vertical_end
-         }
-       )
-       when x_scrollbar >= left and x_scrollbar <= right do
-    clear_vertical_strip(layer_map, x_scrollbar, vertical_start, vertical_end)
-  end
-
-  defp maybe_clear_vertical_scrollbar_strip(layer_map, _context), do: layer_map
-
-  defp maybe_clear_horizontal_scrollbar_strip(
-         layer_map,
-         %ScrollbarContext{
-           config: %{mode: :inset},
-           horizontal?: true,
-           y_scrollbar: y_scrollbar,
-           top: top,
-           bottom: bottom,
-           horizontal_start: horizontal_start,
-           horizontal_end: horizontal_end
-         }
-       )
-       when y_scrollbar >= top and y_scrollbar <= bottom do
-    clear_horizontal_strip(layer_map, y_scrollbar, horizontal_start, horizontal_end)
-  end
-
-  defp maybe_clear_horizontal_scrollbar_strip(layer_map, _context), do: layer_map
-
-  defp viewport_bounds(border, max_x, max_y) do
-    left = if border.left, do: 1, else: 0
-    top = if border.top, do: 1, else: 0
-
-    right = max(max_x - if(border.right, do: 1, else: 0), left)
-    bottom = max(max_y - if(border.bottom, do: 1, else: 0), top)
-
-    {left, top, right, bottom}
-  end
-
-  defp scrollbar_positions(
-         %ScrollbarContext{
-           style: %{border: border},
-           config: config,
-           left: left,
-           top: top,
-           right: right,
-           bottom: bottom
-         },
-         vertical_placement,
-         horizontal_placement
-       ) do
-    x_scrollbar =
-      cond do
-        config.mode == :inset and vertical_placement == :start and border.left -> left - 1
-        config.mode == :inset and vertical_placement == :end and border.right -> right + 1
-        vertical_placement == :start -> left
-        true -> right
-      end
-
-    y_scrollbar =
-      cond do
-        config.mode == :inset and horizontal_placement == :start and border.top -> top - 1
-        config.mode == :inset and horizontal_placement == :end and border.bottom -> bottom + 1
-        horizontal_placement == :start -> top
-        true -> bottom
-      end
-
-    {x_scrollbar, y_scrollbar}
-  end
-
-  defp resolve_visible_axes(%ScrollbarContext{} = context) do
-    config = context.config
-
-    vertical? =
-      BackBreeze.Scrollbar.axis_enabled?(config, :vertical) and
-        BackBreeze.Scrollbar.visible?(
-          config,
-          :vertical,
-          context.content_height,
-          context.viewport_height
-        )
-
-    horizontal? =
-      BackBreeze.Scrollbar.axis_enabled?(config, :horizontal) and
-        BackBreeze.Scrollbar.visible?(
-          config,
-          :horizontal,
-          context.content_width,
-          context.viewport_width
-        )
-
-    {eff_viewport_width, eff_viewport_height} =
-      BackBreeze.Scrollbar.effective_viewport_size(config, %{
-        width: context.viewport_width,
-        height: context.viewport_height,
-        vertical?: vertical?,
-        horizontal?: horizontal?
-      })
-
-    vertical? =
-      BackBreeze.Scrollbar.axis_enabled?(config, :vertical) and
-        BackBreeze.Scrollbar.visible?(
-          config,
-          :vertical,
-          context.content_height,
-          eff_viewport_height
-        )
-
-    horizontal? =
-      BackBreeze.Scrollbar.axis_enabled?(config, :horizontal) and
-        BackBreeze.Scrollbar.visible?(
-          config,
-          :horizontal,
-          context.content_width,
-          eff_viewport_width
-        )
-
-    {eff_viewport_width, eff_viewport_height} =
-      BackBreeze.Scrollbar.effective_viewport_size(config, %{
-        width: context.viewport_width,
-        height: context.viewport_height,
-        vertical?: vertical?,
-        horizontal?: horizontal?
-      })
-
-    %{
-      context
-      | vertical?: vertical?,
-        horizontal?: horizontal?,
-        eff_viewport_width: eff_viewport_width,
-        eff_viewport_height: eff_viewport_height
-    }
-  end
-
-  defp normalize_scroll({top, left}) do
-    top = if is_integer(top), do: max(top, 0), else: 0
-    left = if is_integer(left), do: max(left, 0), else: 0
-    {top, left}
-  end
-
-  defp normalize_scroll(_), do: {0, 0}
-
-  defp trim_axis_for_intersection(start_pos, end_pos, other_enabled?, other_placement) do
-    start_pos = if other_enabled? && other_placement == :start, do: start_pos + 1, else: start_pos
-    end_pos = if other_enabled? && other_placement == :end, do: end_pos - 1, else: end_pos
-
-    {start_pos, max(start_pos - 1, end_pos)}
-  end
-
-  defp clear_vertical_strip(layer_map, x, y_start, y_end) when y_start <= y_end do
-    Enum.reduce(y_start..y_end, layer_map, fn y, acc ->
-      Map.put(acc, {y, x}, {" ", ""})
-    end)
-  end
-
-  defp clear_vertical_strip(layer_map, _x, _y_start, _y_end), do: layer_map
-
-  defp clear_horizontal_strip(layer_map, y, x_start, x_end) when x_start <= x_end do
-    Enum.reduce(x_start..x_end, layer_map, fn x, acc ->
-      Map.put(acc, {y, x}, {" ", ""})
-    end)
-  end
-
-  defp clear_horizontal_strip(layer_map, _y, _x_start, _x_end), do: layer_map
-
-  defp maybe_draw_vertical_scrollbar(layer_map, %ScrollbarContext{vertical?: true} = context) do
-    context
-    |> vertical_axis_context()
-    |> then(&draw_axis_scrollbar(layer_map, &1))
-  end
-
-  defp maybe_draw_vertical_scrollbar(layer_map, _context), do: layer_map
-
-  defp maybe_draw_horizontal_scrollbar(
-         layer_map,
-         %ScrollbarContext{horizontal?: true} = context
-       ) do
-    context
-    |> horizontal_axis_context()
-    |> then(&draw_axis_scrollbar(layer_map, &1))
-  end
-
-  defp maybe_draw_horizontal_scrollbar(layer_map, _context), do: layer_map
-
-  defp vertical_axis_context(%ScrollbarContext{} = context) do
-    %AxisContext{
-      axis: :vertical,
-      config: context.config,
-      fixed: context.x_scrollbar,
-      start: context.vertical_start,
-      stop: context.vertical_end,
-      scroll_value: context.scroll_top,
-      content_size: context.content_height,
-      viewport_size: context.eff_viewport_height
-    }
-  end
-
-  defp horizontal_axis_context(%ScrollbarContext{} = context) do
-    %AxisContext{
-      axis: :horizontal,
-      config: context.config,
-      fixed: context.y_scrollbar,
-      start: context.horizontal_start,
-      stop: context.horizontal_end,
-      scroll_value: context.scroll_left,
-      content_size: context.content_width,
-      viewport_size: context.eff_viewport_width
-    }
-  end
-
-  defp draw_axis_scrollbar(layer_map, %AxisContext{} = axis_context) do
-    total_size = axis_context.stop - axis_context.start + 1
-
-    if total_size <= 0 do
-      layer_map
-    else
-      {track_start, track_end, layer_map} =
-        maybe_draw_axis_arrows(layer_map, axis_context, total_size)
-
-      draw_scroll_track_and_thumb(layer_map, %{
-        axis_context
-        | start: track_start,
-          stop: track_end
-      })
-    end
-  end
-
-  defp maybe_draw_axis_arrows(
-         layer_map,
-         %AxisContext{config: %{arrows: true}} = axis_context,
-         total_size
-       )
-       when total_size >= 3 do
-    layer_map =
-      put_axis_segment(
-        layer_map,
-        axis_context,
-        axis_context.start,
-        axis_arrow_segment(axis_context, :start)
-      )
-
-    layer_map =
-      put_axis_segment(
-        layer_map,
-        axis_context,
-        axis_context.stop,
-        axis_arrow_segment(axis_context, :end)
-      )
-
-    {axis_context.start + 1, axis_context.stop - 1, layer_map}
-  end
-
-  defp maybe_draw_axis_arrows(layer_map, %AxisContext{} = axis_context, _total_size) do
-    {axis_context.start, axis_context.stop, layer_map}
-  end
-
-  defp draw_scroll_track_and_thumb(
-         layer_map,
-         %AxisContext{start: track_start, stop: track_end, viewport_size: viewport_size} =
-           axis_context
-       )
-       when track_start <= track_end and viewport_size > 0 do
-    track_size = track_end - track_start + 1
-
-    {track_segment, thumb_segment} = axis_segments(axis_context)
-
-    max_scroll = max(axis_context.content_size - axis_context.viewport_size, 0)
-    scroll_value = min(max(axis_context.scroll_value, 0), max_scroll)
-
-    thumb_size =
-      BackBreeze.Scrollbar.thumb_size(
-        axis_context.config,
-        track_size,
-        max(axis_context.content_size, axis_context.viewport_size)
-      )
-
-    thumb_start =
-      if max_scroll == 0 or thumb_size >= track_size do
-        track_start
-      else
-        offset = round(scroll_value * (track_size - thumb_size) / max_scroll)
-        track_start + offset
-      end
-
-    thumb_end = min(thumb_start + thumb_size - 1, track_end)
-
-    layer_map =
-      Enum.reduce(track_start..track_end, layer_map, fn pos, acc ->
-        put_axis_segment(acc, axis_context, pos, track_segment)
-      end)
-
-    Enum.reduce(thumb_start..thumb_end, layer_map, fn pos, acc ->
-      put_axis_segment(acc, axis_context, pos, thumb_segment)
-    end)
-  end
-
-  defp draw_scroll_track_and_thumb(layer_map, _axis_context), do: layer_map
-
-  defp axis_segments(%AxisContext{axis: :vertical, config: config}) do
-    {config.vertical.track, config.vertical.thumb}
-  end
-
-  defp axis_segments(%AxisContext{axis: :horizontal, config: config}) do
-    {config.horizontal.track, config.horizontal.thumb}
-  end
-
-  defp axis_arrow_segment(%AxisContext{axis: :vertical, config: config}, :start),
-    do: config.vertical.arrow_start
-
-  defp axis_arrow_segment(%AxisContext{axis: :vertical, config: config}, :end),
-    do: config.vertical.arrow_end
-
-  defp axis_arrow_segment(%AxisContext{axis: :horizontal, config: config}, :start),
-    do: config.horizontal.arrow_start
-
-  defp axis_arrow_segment(%AxisContext{axis: :horizontal, config: config}, :end),
-    do: config.horizontal.arrow_end
-
-  defp put_axis_segment(layer_map, %AxisContext{} = axis_context, pos, segment) do
-    put_segment(layer_map, axis_point(axis_context, pos), segment)
-  end
-
-  defp axis_point(%AxisContext{axis: :vertical, fixed: fixed}, pos), do: {pos, fixed}
-  defp axis_point(%AxisContext{axis: :horizontal, fixed: fixed}, pos), do: {fixed, pos}
-
-  defp maybe_draw_intersection(
-         layer_map,
-         %ScrollbarContext{vertical?: true, horizontal?: true} = context
-       ) do
-    put_segment(
-      layer_map,
-      {context.y_scrollbar, context.x_scrollbar},
-      context.config.intersection
-    )
-  end
-
-  defp maybe_draw_intersection(layer_map, _context), do: layer_map
-
-  defp put_segment(layer_map, _point, nil), do: layer_map
-
-  defp put_segment(layer_map, point, segment) do
-    char = BackBreeze.Scrollbar.segment_char(segment)
-
-    if is_binary(char) do
-      Map.put(layer_map, point, {char, BackBreeze.Scrollbar.style_sequence(segment)})
-    else
-      layer_map
-    end
   end
 
   defp clip_child_layer_map(layer_map, %{overflow: :hidden, border: border}, max_x, max_y)

--- a/lib/back_breeze/box.ex
+++ b/lib/back_breeze/box.ex
@@ -469,8 +469,17 @@ defmodule BackBreeze.Box do
           vertical_placement = BackBreeze.Scrollbar.placement(config, :vertical)
           horizontal_placement = BackBreeze.Scrollbar.placement(config, :horizontal)
 
-          x_scrollbar = if vertical_placement == :start, do: left, else: right
-          y_scrollbar = if horizontal_placement == :start, do: top, else: bottom
+          {x_scrollbar, y_scrollbar} =
+            scrollbar_positions(
+              style.border,
+              config,
+              left,
+              top,
+              right,
+              bottom,
+              vertical_placement,
+              horizontal_placement
+            )
 
           {vertical_start, vertical_end} =
             trim_axis_for_intersection(top, bottom, horizontal?, horizontal_placement)
@@ -479,14 +488,16 @@ defmodule BackBreeze.Box do
             trim_axis_for_intersection(left, right, vertical?, vertical_placement)
 
           layer_map =
-            if config.mode == :inset and vertical? do
+            if config.mode == :inset and vertical? and x_scrollbar >= left and
+                 x_scrollbar <= right do
               clear_vertical_strip(layer_map, x_scrollbar, vertical_start, vertical_end)
             else
               layer_map
             end
 
           layer_map =
-            if config.mode == :inset and horizontal? do
+            if config.mode == :inset and horizontal? and y_scrollbar >= top and
+                 y_scrollbar <= bottom do
               clear_horizontal_strip(layer_map, y_scrollbar, horizontal_start, horizontal_end)
             else
               layer_map
@@ -546,6 +557,35 @@ defmodule BackBreeze.Box do
     bottom = max(max_y - if(border.bottom, do: 1, else: 0), top)
 
     {left, top, right, bottom}
+  end
+
+  defp scrollbar_positions(
+         border,
+         config,
+         left,
+         top,
+         right,
+         bottom,
+         vertical_placement,
+         horizontal_placement
+       ) do
+    x_scrollbar =
+      cond do
+        config.mode == :inset and vertical_placement == :start and border.left -> left - 1
+        config.mode == :inset and vertical_placement == :end and border.right -> right + 1
+        vertical_placement == :start -> left
+        true -> right
+      end
+
+    y_scrollbar =
+      cond do
+        config.mode == :inset and horizontal_placement == :start and border.top -> top - 1
+        config.mode == :inset and horizontal_placement == :end and border.bottom -> bottom + 1
+        horizontal_placement == :start -> top
+        true -> bottom
+      end
+
+    {x_scrollbar, y_scrollbar}
   end
 
   defp resolve_visible_axes(

--- a/lib/back_breeze/scrollbar.ex
+++ b/lib/back_breeze/scrollbar.ex
@@ -21,7 +21,7 @@ defmodule BackBreeze.Scrollbar do
             vertical_placement: nil,
             horizontal_placement: nil,
             min_thumb_size: 1,
-            sizing: {:fixed, 1},
+            sizing: :proportional,
             arrows: false,
             vertical: %{},
             horizontal: %{},

--- a/lib/back_breeze/scrollbar.ex
+++ b/lib/back_breeze/scrollbar.ex
@@ -13,6 +13,16 @@ defmodule BackBreeze.Scrollbar do
               style: ""
   end
 
+  defmodule AxisSegmentsContext do
+    @moduledoc false
+
+    defstruct base: %{},
+              common_thumb: %{},
+              common_track: %{},
+              overrides: %{},
+              fallback_color: nil
+  end
+
   defstruct enabled: false,
             axis: :vertical,
             show: :auto,
@@ -80,6 +90,7 @@ defmodule BackBreeze.Scrollbar do
       |> Map.get(:horizontal_placement)
       |> normalize_optional_placement()
 
+    fallback_color = Map.get(style, :border_color)
     common_thumb = Map.get(map, :thumb, %{})
     common_track = Map.get(map, :track, %{})
 
@@ -87,26 +98,26 @@ defmodule BackBreeze.Scrollbar do
     horizontal_overrides = Map.get(map, :horizontal, %{})
 
     vertical =
-      normalize_axis_segments(
-        base.vertical,
-        common_thumb,
-        common_track,
-        vertical_overrides,
-        Map.get(style, :border_color)
-      )
+      normalize_axis_segments(%AxisSegmentsContext{
+        base: base.vertical,
+        common_thumb: common_thumb,
+        common_track: common_track,
+        overrides: vertical_overrides,
+        fallback_color: fallback_color
+      })
 
     horizontal =
-      normalize_axis_segments(
-        base.horizontal,
-        common_thumb,
-        common_track,
-        horizontal_overrides,
-        Map.get(style, :border_color)
-      )
+      normalize_axis_segments(%AxisSegmentsContext{
+        base: base.horizontal,
+        common_thumb: common_thumb,
+        common_track: common_track,
+        overrides: horizontal_overrides,
+        fallback_color: fallback_color
+      })
 
     intersection =
       base.intersection
-      |> merge_segment(Map.get(map, :intersection, %{}), Map.get(style, :border_color))
+      |> merge_segment(Map.get(map, :intersection, %{}), fallback_color)
       |> segment_to_renderable()
 
     %__MODULE__{
@@ -147,14 +158,26 @@ defmodule BackBreeze.Scrollbar do
 
   @spec effective_viewport_size(t(), non_neg_integer(), non_neg_integer(), boolean(), boolean()) ::
           {non_neg_integer(), non_neg_integer()}
-  def effective_viewport_size(%__MODULE__{mode: :inset}, width, height, vertical?, horizontal?) do
+  def effective_viewport_size(%__MODULE__{} = config, width, height, vertical?, horizontal?) do
+    effective_viewport_size(config, %{
+      width: width,
+      height: height,
+      vertical?: vertical?,
+      horizontal?: horizontal?
+    })
+  end
+
+  @spec effective_viewport_size(t(), map()) :: {non_neg_integer(), non_neg_integer()}
+  def effective_viewport_size(
+        %__MODULE__{mode: :inset},
+        %{width: width, height: height, vertical?: vertical?, horizontal?: horizontal?}
+      ) do
     width = if vertical?, do: max(width - 1, 0), else: width
     height = if horizontal?, do: max(height - 1, 0), else: height
     {width, height}
   end
 
-  def effective_viewport_size(_config, width, height, _vertical?, _horizontal?),
-    do: {width, height}
+  def effective_viewport_size(_config, %{width: width, height: height}), do: {width, height}
 
   @spec placement(t(), :vertical | :horizontal) :: :start | :end
   def placement(%__MODULE__{} = config, :vertical),
@@ -258,7 +281,15 @@ defmodule BackBreeze.Scrollbar do
 
   defp normalize_int(_value, default), do: default
 
-  defp normalize_axis_segments(base, common_thumb, common_track, overrides, fallback_color) do
+  defp normalize_axis_segments(%AxisSegmentsContext{
+         base: base,
+         common_thumb: common_thumb,
+         common_track: common_track,
+         overrides: overrides,
+         fallback_color: fallback_color
+       }) do
+    overrides = if is_map(overrides), do: overrides, else: %{}
+
     thumb =
       base.thumb
       |> merge_segment(common_thumb, fallback_color)

--- a/lib/back_breeze/scrollbar.ex
+++ b/lib/back_breeze/scrollbar.ex
@@ -1,5 +1,51 @@
+defmodule BackBreeze.Scrollbar.Context do
+  @moduledoc false
+
+  defstruct style: %BackBreeze.Style{},
+            max_x: 0,
+            max_y: 0,
+            left: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+            viewport_width: 0,
+            viewport_height: 0,
+            content_width: 0,
+            content_height: 0,
+            vertical?: false,
+            horizontal?: false,
+            eff_viewport_width: 0,
+            eff_viewport_height: 0,
+            vertical_placement: :end,
+            horizontal_placement: :end,
+            x_scrollbar: 0,
+            y_scrollbar: 0,
+            vertical_start: 0,
+            vertical_end: -1,
+            horizontal_start: 0,
+            horizontal_end: -1,
+            scroll_top: 0,
+            scroll_left: 0
+end
+
+defmodule BackBreeze.Scrollbar.AxisContext do
+  @moduledoc false
+
+  defstruct axis: :vertical,
+            config: nil,
+            fixed: 0,
+            start: 0,
+            stop: -1,
+            scroll_value: 0,
+            content_size: 0,
+            viewport_size: 0
+end
+
 defmodule BackBreeze.Scrollbar do
   @moduledoc false
+
+  alias BackBreeze.Scrollbar.Context
+  alias BackBreeze.Scrollbar.AxisContext
 
   defmodule Segment do
     @moduledoc false
@@ -11,16 +57,6 @@ defmodule BackBreeze.Scrollbar do
               italic: false,
               reverse: false,
               style: ""
-  end
-
-  defmodule AxisSegmentsContext do
-    @moduledoc false
-
-    defstruct base: %{},
-              common_thumb: %{},
-              common_track: %{},
-              overrides: %{},
-              fallback_color: nil
   end
 
   defstruct enabled: false,
@@ -40,9 +76,6 @@ defmodule BackBreeze.Scrollbar do
   @type t :: %__MODULE__{}
 
   @axes [:vertical, :horizontal, :both]
-  @shows [:auto, :always, :never, :focus]
-  @modes [:overlay, :inset]
-  @placements [:start, :end]
 
   @spec normalize(term(), map()) :: t()
   def normalize(value, style \\ %BackBreeze.Style{})
@@ -65,76 +98,42 @@ defmodule BackBreeze.Scrollbar do
 
   def normalize(map, style) when is_map(map) do
     base = default(style)
-
-    axis = normalize_axis(Map.get(map, :axis, base.axis))
-    show = normalize_show(Map.get(map, :show, base.show))
-    mode = normalize_mode(Map.get(map, :mode, base.mode))
-    placement = normalize_placement(Map.get(map, :placement, base.placement))
-
-    min_thumb_size =
-      map
-      |> Map.get(:min_thumb_size, base.min_thumb_size)
-      |> normalize_int(base.min_thumb_size)
-      |> max(1)
-
-    sizing = normalize_sizing(Map.get(map, :sizing, base.sizing))
-    arrows = normalize_boolean(Map.get(map, :arrows, base.arrows), base.arrows)
-
-    vertical_placement =
-      map
-      |> Map.get(:vertical_placement)
-      |> normalize_optional_placement()
-
-    horizontal_placement =
-      map
-      |> Map.get(:horizontal_placement)
-      |> normalize_optional_placement()
-
     fallback_color = Map.get(style, :border_color)
     common_thumb = Map.get(map, :thumb, %{})
     common_track = Map.get(map, :track, %{})
 
-    vertical_overrides = Map.get(map, :vertical, %{})
-    horizontal_overrides = Map.get(map, :horizontal, %{})
-
     vertical =
-      normalize_axis_segments(%AxisSegmentsContext{
-        base: base.vertical,
-        common_thumb: common_thumb,
-        common_track: common_track,
-        overrides: vertical_overrides,
-        fallback_color: fallback_color
-      })
+      build_axis_segments(
+        base.vertical,
+        common_thumb,
+        common_track,
+        Map.get(map, :vertical, %{}),
+        fallback_color
+      )
 
     horizontal =
-      normalize_axis_segments(%AxisSegmentsContext{
-        base: base.horizontal,
-        common_thumb: common_thumb,
-        common_track: common_track,
-        overrides: horizontal_overrides,
-        fallback_color: fallback_color
-      })
+      build_axis_segments(
+        base.horizontal,
+        common_thumb,
+        common_track,
+        Map.get(map, :horizontal, %{}),
+        fallback_color
+      )
 
     intersection =
       base.intersection
       |> merge_segment(Map.get(map, :intersection, %{}), fallback_color)
       |> segment_to_renderable()
 
-    %__MODULE__{
-      enabled: true,
-      axis: axis,
-      show: show,
-      mode: mode,
-      placement: placement,
-      vertical_placement: vertical_placement,
-      horizontal_placement: horizontal_placement,
-      min_thumb_size: min_thumb_size,
-      sizing: sizing,
-      arrows: arrows,
-      vertical: vertical,
-      horizontal: horizontal,
-      intersection: intersection
-    }
+    struct(
+      base,
+      Map.merge(map, %{
+        enabled: true,
+        vertical: vertical,
+        horizontal: horizontal,
+        intersection: intersection
+      })
+    )
   end
 
   def normalize(_other, style), do: normalize(true, style)
@@ -211,6 +210,442 @@ defmodule BackBreeze.Scrollbar do
   def segment_char(%Segment{char: char}), do: char
   def segment_char(_), do: nil
 
+  @spec add_to_layer_map(map(), map()) :: map()
+  def add_to_layer_map(layer_map, options)
+      when is_map(options) and not is_struct(options, Context) do
+    options
+    |> build_context()
+    |> then(&add_to_layer_map(layer_map, &1))
+  end
+
+  def add_to_layer_map(layer_map, %Context{} = context) do
+    cond do
+      context.style.overflow != :hidden or !context.style.scrollbar.enabled ->
+        layer_map
+
+      !is_integer(context.max_x) or !is_integer(context.max_y) ->
+        layer_map
+
+      true ->
+        context = prepare_context(context)
+
+        if !context.vertical? and !context.horizontal? do
+          layer_map
+        else
+          layer_map
+          |> maybe_clear_scrollbar_strips(context)
+          |> maybe_draw_vertical_scrollbar(context)
+          |> maybe_draw_horizontal_scrollbar(context)
+          |> maybe_draw_intersection(context)
+        end
+    end
+  end
+
+  defp build_context(%{style: style} = options) do
+    normalized = normalize(style.scrollbar, style)
+    style = %{style | scrollbar: normalized}
+    {scroll_top, scroll_left} = Map.get(options, :scroll, {0, 0})
+
+    %Context{
+      style: style,
+      content_width: Map.get(options, :content_width, 0),
+      content_height: Map.get(options, :content_height, 0),
+      scroll_top: scroll_top,
+      scroll_left: scroll_left,
+      max_x: Map.get(options, :max_x),
+      max_y: Map.get(options, :max_y)
+    }
+  end
+
+  defp prepare_context(%Context{} = context) do
+    {left, top, right, bottom} =
+      viewport_bounds(context.style.border, context.max_x, context.max_y)
+
+    viewport_width = max(right - left + 1, 0)
+    viewport_height = max(bottom - top + 1, 0)
+
+    %{
+      context
+      | left: left,
+        top: top,
+        right: right,
+        bottom: bottom,
+        viewport_width: viewport_width,
+        viewport_height: viewport_height,
+        content_width: max(context.content_width, viewport_width),
+        content_height: max(context.content_height, viewport_height)
+    }
+    |> resolve_visible_axes()
+    |> set_scrollbar_positions()
+  end
+
+  defp set_scrollbar_positions(%Context{} = context) do
+    vertical_placement = placement(context.style.scrollbar, :vertical)
+    horizontal_placement = placement(context.style.scrollbar, :horizontal)
+
+    {x_scrollbar, y_scrollbar} =
+      scrollbar_positions(context, vertical_placement, horizontal_placement)
+
+    {vertical_start, vertical_end} =
+      trim_axis_for_intersection(
+        context.top,
+        context.bottom,
+        context.horizontal? and y_scrollbar >= context.top and y_scrollbar <= context.bottom,
+        horizontal_placement
+      )
+
+    {horizontal_start, horizontal_end} =
+      trim_axis_for_intersection(
+        context.left,
+        context.right,
+        context.vertical? and x_scrollbar >= context.left and x_scrollbar <= context.right,
+        vertical_placement
+      )
+
+    %{
+      context
+      | vertical_placement: vertical_placement,
+        horizontal_placement: horizontal_placement,
+        x_scrollbar: x_scrollbar,
+        y_scrollbar: y_scrollbar,
+        vertical_start: vertical_start,
+        vertical_end: vertical_end,
+        horizontal_start: horizontal_start,
+        horizontal_end: horizontal_end
+    }
+  end
+
+  defp maybe_clear_scrollbar_strips(layer_map, context) do
+    layer_map
+    |> maybe_clear_vertical_scrollbar_strip(context)
+    |> maybe_clear_horizontal_scrollbar_strip(context)
+  end
+
+  defp maybe_clear_vertical_scrollbar_strip(
+         layer_map,
+         %Context{
+           style: %{scrollbar: %{mode: :inset}},
+           vertical?: true,
+           x_scrollbar: x_scrollbar,
+           left: left,
+           right: right,
+           vertical_start: vertical_start,
+           vertical_end: vertical_end
+         }
+       )
+       when x_scrollbar >= left and x_scrollbar <= right do
+    clear_vertical_strip(layer_map, x_scrollbar, vertical_start, vertical_end)
+  end
+
+  defp maybe_clear_vertical_scrollbar_strip(layer_map, _context), do: layer_map
+
+  defp maybe_clear_horizontal_scrollbar_strip(
+         layer_map,
+         %Context{
+           style: %{scrollbar: %{mode: :inset}},
+           horizontal?: true,
+           y_scrollbar: y_scrollbar,
+           top: top,
+           bottom: bottom,
+           horizontal_start: horizontal_start,
+           horizontal_end: horizontal_end
+         }
+       )
+       when y_scrollbar >= top and y_scrollbar <= bottom do
+    clear_horizontal_strip(layer_map, y_scrollbar, horizontal_start, horizontal_end)
+  end
+
+  defp maybe_clear_horizontal_scrollbar_strip(layer_map, _context), do: layer_map
+
+  defp viewport_bounds(border, max_x, max_y) do
+    left = if border.left, do: 1, else: 0
+    top = if border.top, do: 1, else: 0
+
+    right = max(max_x - if(border.right, do: 1, else: 0), left)
+    bottom = max(max_y - if(border.bottom, do: 1, else: 0), top)
+
+    {left, top, right, bottom}
+  end
+
+  defp scrollbar_positions(
+         %Context{
+           style: %{border: border, scrollbar: config},
+           left: left,
+           top: top,
+           right: right,
+           bottom: bottom
+         },
+         vertical_placement,
+         horizontal_placement
+       ) do
+    x_scrollbar =
+      cond do
+        config.mode == :inset and vertical_placement == :start and border.left -> left - 1
+        config.mode == :inset and vertical_placement == :end and border.right -> right + 1
+        vertical_placement == :start -> left
+        true -> right
+      end
+
+    y_scrollbar =
+      cond do
+        config.mode == :inset and horizontal_placement == :start and border.top -> top - 1
+        config.mode == :inset and horizontal_placement == :end and border.bottom -> bottom + 1
+        horizontal_placement == :start -> top
+        true -> bottom
+      end
+
+    {x_scrollbar, y_scrollbar}
+  end
+
+  defp resolve_visible_axes(%Context{} = context) do
+    config = context.style.scrollbar
+
+    vertical? =
+      axis_enabled?(config, :vertical) and
+        visible?(config, :vertical, context.content_height, context.viewport_height)
+
+    horizontal? =
+      axis_enabled?(config, :horizontal) and
+        visible?(config, :horizontal, context.content_width, context.viewport_width)
+
+    {eff_viewport_width, eff_viewport_height} =
+      effective_viewport_size(config, %{
+        width: context.viewport_width,
+        height: context.viewport_height,
+        vertical?: vertical?,
+        horizontal?: horizontal?
+      })
+
+    vertical? =
+      axis_enabled?(config, :vertical) and
+        visible?(config, :vertical, context.content_height, eff_viewport_height)
+
+    horizontal? =
+      axis_enabled?(config, :horizontal) and
+        visible?(config, :horizontal, context.content_width, eff_viewport_width)
+
+    {eff_viewport_width, eff_viewport_height} =
+      effective_viewport_size(config, %{
+        width: context.viewport_width,
+        height: context.viewport_height,
+        vertical?: vertical?,
+        horizontal?: horizontal?
+      })
+
+    %{
+      context
+      | vertical?: vertical?,
+        horizontal?: horizontal?,
+        eff_viewport_width: eff_viewport_width,
+        eff_viewport_height: eff_viewport_height
+    }
+  end
+
+  defp trim_axis_for_intersection(start_pos, end_pos, other_enabled?, other_placement) do
+    start_pos = if other_enabled? && other_placement == :start, do: start_pos + 1, else: start_pos
+    end_pos = if other_enabled? && other_placement == :end, do: end_pos - 1, else: end_pos
+
+    {start_pos, max(start_pos - 1, end_pos)}
+  end
+
+  defp clear_vertical_strip(layer_map, x, y_start, y_end) when y_start <= y_end do
+    Enum.reduce(y_start..y_end, layer_map, fn y, acc ->
+      Map.put(acc, {y, x}, {" ", ""})
+    end)
+  end
+
+  defp clear_vertical_strip(layer_map, _x, _y_start, _y_end), do: layer_map
+
+  defp clear_horizontal_strip(layer_map, y, x_start, x_end) when x_start <= x_end do
+    Enum.reduce(x_start..x_end, layer_map, fn x, acc ->
+      Map.put(acc, {y, x}, {" ", ""})
+    end)
+  end
+
+  defp clear_horizontal_strip(layer_map, _y, _x_start, _x_end), do: layer_map
+
+  defp maybe_draw_vertical_scrollbar(layer_map, %Context{vertical?: true} = context) do
+    context
+    |> vertical_axis_context()
+    |> then(&draw_axis_scrollbar(layer_map, &1))
+  end
+
+  defp maybe_draw_vertical_scrollbar(layer_map, _context), do: layer_map
+
+  defp maybe_draw_horizontal_scrollbar(layer_map, %Context{horizontal?: true} = context) do
+    context
+    |> horizontal_axis_context()
+    |> then(&draw_axis_scrollbar(layer_map, &1))
+  end
+
+  defp maybe_draw_horizontal_scrollbar(layer_map, _context), do: layer_map
+
+  defp vertical_axis_context(%Context{} = context) do
+    %AxisContext{
+      axis: :vertical,
+      config: context.style.scrollbar,
+      fixed: context.x_scrollbar,
+      start: context.vertical_start,
+      stop: context.vertical_end,
+      scroll_value: context.scroll_top,
+      content_size: context.content_height,
+      viewport_size: context.eff_viewport_height
+    }
+  end
+
+  defp horizontal_axis_context(%Context{} = context) do
+    %AxisContext{
+      axis: :horizontal,
+      config: context.style.scrollbar,
+      fixed: context.y_scrollbar,
+      start: context.horizontal_start,
+      stop: context.horizontal_end,
+      scroll_value: context.scroll_left,
+      content_size: context.content_width,
+      viewport_size: context.eff_viewport_width
+    }
+  end
+
+  defp draw_axis_scrollbar(layer_map, %AxisContext{} = axis_context) do
+    total_size = axis_context.stop - axis_context.start + 1
+
+    if total_size <= 0 do
+      layer_map
+    else
+      {track_start, track_end, layer_map} =
+        maybe_draw_axis_arrows(layer_map, axis_context, total_size)
+
+      draw_scroll_track_and_thumb(layer_map, %{
+        axis_context
+        | start: track_start,
+          stop: track_end
+      })
+    end
+  end
+
+  defp maybe_draw_axis_arrows(
+         layer_map,
+         %AxisContext{config: %{arrows: true}} = axis_context,
+         total_size
+       )
+       when total_size >= 3 do
+    layer_map =
+      put_axis_segment(
+        layer_map,
+        axis_context,
+        axis_context.start,
+        axis_arrow_segment(axis_context, :start)
+      )
+
+    layer_map =
+      put_axis_segment(
+        layer_map,
+        axis_context,
+        axis_context.stop,
+        axis_arrow_segment(axis_context, :end)
+      )
+
+    {axis_context.start + 1, axis_context.stop - 1, layer_map}
+  end
+
+  defp maybe_draw_axis_arrows(layer_map, %AxisContext{} = axis_context, _total_size) do
+    {axis_context.start, axis_context.stop, layer_map}
+  end
+
+  defp draw_scroll_track_and_thumb(
+         layer_map,
+         %AxisContext{start: track_start, stop: track_end, viewport_size: viewport_size} =
+           axis_context
+       )
+       when track_start <= track_end and viewport_size > 0 do
+    track_size = track_end - track_start + 1
+
+    {track_segment, thumb_segment} = axis_segments(axis_context)
+
+    max_scroll = max(axis_context.content_size - axis_context.viewport_size, 0)
+    scroll_value = min(max(axis_context.scroll_value, 0), max_scroll)
+
+    thumb_size =
+      thumb_size(
+        axis_context.config,
+        track_size,
+        max(axis_context.content_size, axis_context.viewport_size)
+      )
+
+    thumb_start =
+      if max_scroll == 0 or thumb_size >= track_size do
+        track_start
+      else
+        offset = round(scroll_value * (track_size - thumb_size) / max_scroll)
+        track_start + offset
+      end
+
+    thumb_end = min(thumb_start + thumb_size - 1, track_end)
+
+    layer_map =
+      Enum.reduce(track_start..track_end, layer_map, fn pos, acc ->
+        put_axis_segment(acc, axis_context, pos, track_segment)
+      end)
+
+    Enum.reduce(thumb_start..thumb_end, layer_map, fn pos, acc ->
+      put_axis_segment(acc, axis_context, pos, thumb_segment)
+    end)
+  end
+
+  defp draw_scroll_track_and_thumb(layer_map, _axis_context), do: layer_map
+
+  defp axis_segments(%AxisContext{axis: :vertical, config: config}) do
+    {config.vertical.track, config.vertical.thumb}
+  end
+
+  defp axis_segments(%AxisContext{axis: :horizontal, config: config}) do
+    {config.horizontal.track, config.horizontal.thumb}
+  end
+
+  defp axis_arrow_segment(%AxisContext{axis: :vertical, config: config}, :start),
+    do: config.vertical.arrow_start
+
+  defp axis_arrow_segment(%AxisContext{axis: :vertical, config: config}, :end),
+    do: config.vertical.arrow_end
+
+  defp axis_arrow_segment(%AxisContext{axis: :horizontal, config: config}, :start),
+    do: config.horizontal.arrow_start
+
+  defp axis_arrow_segment(%AxisContext{axis: :horizontal, config: config}, :end),
+    do: config.horizontal.arrow_end
+
+  defp put_axis_segment(layer_map, %AxisContext{} = axis_context, pos, segment) do
+    put_segment(layer_map, axis_point(axis_context, pos), segment)
+  end
+
+  defp axis_point(%AxisContext{axis: :vertical, fixed: fixed}, pos), do: {pos, fixed}
+  defp axis_point(%AxisContext{axis: :horizontal, fixed: fixed}, pos), do: {fixed, pos}
+
+  defp maybe_draw_intersection(
+         layer_map,
+         %Context{vertical?: true, horizontal?: true} = context
+       ) do
+    put_segment(
+      layer_map,
+      {context.y_scrollbar, context.x_scrollbar},
+      context.style.scrollbar.intersection
+    )
+  end
+
+  defp maybe_draw_intersection(layer_map, _context), do: layer_map
+
+  defp put_segment(layer_map, _point, nil), do: layer_map
+
+  defp put_segment(layer_map, point, segment) do
+    char = segment_char(segment)
+
+    if is_binary(char) do
+      Map.put(layer_map, point, {char, style_sequence(segment)})
+    else
+      layer_map
+    end
+  end
+
   defp default(style) do
     border_color = Map.get(style, :border_color)
 
@@ -228,66 +663,12 @@ defmodule BackBreeze.Scrollbar do
         arrow_start: %Segment{char: "◀", foreground_color: border_color},
         arrow_end: %Segment{char: "▶", foreground_color: border_color}
       },
-      intersection: %Segment{char: "┼", foreground_color: border_color}
+      intersection: %Segment{char: "┘", foreground_color: border_color}
     }
     |> renderable_segments()
   end
 
-  defp normalize_axis(value) when value in @axes, do: value
-  defp normalize_axis(_), do: :vertical
-
-  defp normalize_show(value) when value in @shows, do: value
-  defp normalize_show(_), do: :auto
-
-  defp normalize_mode(value) when value in @modes, do: value
-  defp normalize_mode(_), do: :inset
-
-  defp normalize_placement(value) when value in @placements, do: value
-  defp normalize_placement(_), do: :end
-
-  defp normalize_optional_placement(value) when value in @placements, do: value
-  defp normalize_optional_placement(_), do: nil
-
-  defp normalize_sizing(:proportional), do: :proportional
-
-  defp normalize_sizing({:fixed, value}) do
-    {:fixed, max(normalize_int(value, 1), 1)}
-  end
-
-  defp normalize_sizing(_), do: :proportional
-
-  defp normalize_boolean(value, _default) when is_boolean(value), do: value
-
-  defp normalize_boolean(value, default) when is_binary(value) do
-    case String.downcase(String.trim(value)) do
-      "true" -> true
-      "1" -> true
-      "false" -> false
-      "0" -> false
-      _ -> default
-    end
-  end
-
-  defp normalize_boolean(_value, default), do: default
-
-  defp normalize_int(value, _default) when is_integer(value), do: value
-
-  defp normalize_int(value, default) when is_binary(value) do
-    case Integer.parse(value) do
-      {value, ""} -> value
-      _ -> default
-    end
-  end
-
-  defp normalize_int(_value, default), do: default
-
-  defp normalize_axis_segments(%AxisSegmentsContext{
-         base: base,
-         common_thumb: common_thumb,
-         common_track: common_track,
-         overrides: overrides,
-         fallback_color: fallback_color
-       }) do
+  defp build_axis_segments(base, common_thumb, common_track, overrides, fallback_color) do
     overrides = if is_map(overrides), do: overrides, else: %{}
 
     thumb =
@@ -322,18 +703,13 @@ defmodule BackBreeze.Scrollbar do
     segment =
       %Segment{
         segment
-        | char: normalize_char(char, segment.char),
+        | char: char,
           foreground_color:
-            map
-            |> Map.get(:foreground_color, segment.foreground_color || fallback_color)
-            |> normalize_color(segment.foreground_color || fallback_color),
-          background_color:
-            map
-            |> Map.get(:background_color, segment.background_color)
-            |> normalize_color(segment.background_color),
-          bold: normalize_boolean(Map.get(map, :bold, segment.bold), segment.bold),
-          italic: normalize_boolean(Map.get(map, :italic, segment.italic), segment.italic),
-          reverse: normalize_boolean(Map.get(map, :reverse, segment.reverse), segment.reverse)
+            Map.get(map, :foreground_color, segment.foreground_color || fallback_color),
+          background_color: Map.get(map, :background_color, segment.background_color),
+          bold: Map.get(map, :bold, segment.bold),
+          italic: Map.get(map, :italic, segment.italic),
+          reverse: Map.get(map, :reverse, segment.reverse)
       }
 
     cond do
@@ -343,23 +719,6 @@ defmodule BackBreeze.Scrollbar do
   end
 
   defp merge_segment(%Segment{} = segment, _other, _fallback_color), do: segment
-
-  defp normalize_char(nil, default), do: default
-
-  defp normalize_char(char, _default) when is_binary(char) do
-    char
-    |> String.graphemes()
-    |> List.first()
-  end
-
-  defp normalize_char(_char, default), do: default
-
-  defp normalize_color(nil, default), do: default
-
-  defp normalize_color(value, _default) when is_integer(value) and value >= 0 and value <= 255,
-    do: value
-
-  defp normalize_color(_value, default), do: default
 
   defp renderable_segments(%__MODULE__{} = config) do
     %{
@@ -389,13 +748,10 @@ defmodule BackBreeze.Scrollbar do
       |> maybe_style(:italic, segment.italic)
       |> maybe_style(:reverse, segment.reverse)
 
-    token = "§"
-
     style_prefix =
       style
-      |> Termite.Style.render_to_string(token)
-      |> String.split(token, parts: 2)
-      |> List.first()
+      |> Termite.Style.render_to_string("")
+      |> String.trim_trailing(Termite.Style.reset_code())
 
     %{segment | style: style_prefix}
   end

--- a/lib/back_breeze/scrollbar.ex
+++ b/lib/back_breeze/scrollbar.ex
@@ -21,7 +21,7 @@ defmodule BackBreeze.Scrollbar do
             vertical_placement: nil,
             horizontal_placement: nil,
             min_thumb_size: 1,
-            sizing: :proportional,
+            sizing: {:fixed, 1},
             arrows: false,
             vertical: %{},
             horizontal: %{},

--- a/lib/back_breeze/scrollbar.ex
+++ b/lib/back_breeze/scrollbar.ex
@@ -1,0 +1,382 @@
+defmodule BackBreeze.Scrollbar do
+  @moduledoc false
+
+  defmodule Segment do
+    @moduledoc false
+
+    defstruct char: nil,
+              foreground_color: nil,
+              background_color: nil,
+              bold: false,
+              italic: false,
+              reverse: false,
+              style: ""
+  end
+
+  defstruct enabled: false,
+            axis: :vertical,
+            show: :auto,
+            mode: :inset,
+            placement: :end,
+            vertical_placement: nil,
+            horizontal_placement: nil,
+            min_thumb_size: 1,
+            sizing: :proportional,
+            arrows: false,
+            vertical: %{},
+            horizontal: %{},
+            intersection: nil
+
+  @type t :: %__MODULE__{}
+
+  @axes [:vertical, :horizontal, :both]
+  @shows [:auto, :always, :never, :focus]
+  @modes [:overlay, :inset]
+  @placements [:start, :end]
+
+  @spec normalize(term(), map()) :: t()
+  def normalize(value, style \\ %BackBreeze.Style{})
+
+  def normalize(nil, style), do: normalize(false, style)
+
+  def normalize(false, _style), do: %__MODULE__{enabled: false}
+
+  def normalize(true, style) do
+    default(style)
+    |> Map.put(:enabled, true)
+  end
+
+  def normalize(axis, style) when axis in @axes do
+    default(style)
+    |> Map.merge(%{enabled: true, axis: axis})
+  end
+
+  def normalize(%__MODULE__{} = scrollbar, _style), do: scrollbar
+
+  def normalize(map, style) when is_map(map) do
+    base = default(style)
+
+    axis = normalize_axis(Map.get(map, :axis, base.axis))
+    show = normalize_show(Map.get(map, :show, base.show))
+    mode = normalize_mode(Map.get(map, :mode, base.mode))
+    placement = normalize_placement(Map.get(map, :placement, base.placement))
+
+    min_thumb_size =
+      map
+      |> Map.get(:min_thumb_size, base.min_thumb_size)
+      |> normalize_int(base.min_thumb_size)
+      |> max(1)
+
+    sizing = normalize_sizing(Map.get(map, :sizing, base.sizing))
+    arrows = normalize_boolean(Map.get(map, :arrows, base.arrows), base.arrows)
+
+    vertical_placement =
+      map
+      |> Map.get(:vertical_placement)
+      |> normalize_optional_placement()
+
+    horizontal_placement =
+      map
+      |> Map.get(:horizontal_placement)
+      |> normalize_optional_placement()
+
+    common_thumb = Map.get(map, :thumb, %{})
+    common_track = Map.get(map, :track, %{})
+
+    vertical_overrides = Map.get(map, :vertical, %{})
+    horizontal_overrides = Map.get(map, :horizontal, %{})
+
+    vertical =
+      normalize_axis_segments(
+        base.vertical,
+        common_thumb,
+        common_track,
+        vertical_overrides,
+        Map.get(style, :border_color)
+      )
+
+    horizontal =
+      normalize_axis_segments(
+        base.horizontal,
+        common_thumb,
+        common_track,
+        horizontal_overrides,
+        Map.get(style, :border_color)
+      )
+
+    intersection =
+      base.intersection
+      |> merge_segment(Map.get(map, :intersection, %{}), Map.get(style, :border_color))
+      |> segment_to_renderable()
+
+    %__MODULE__{
+      enabled: true,
+      axis: axis,
+      show: show,
+      mode: mode,
+      placement: placement,
+      vertical_placement: vertical_placement,
+      horizontal_placement: horizontal_placement,
+      min_thumb_size: min_thumb_size,
+      sizing: sizing,
+      arrows: arrows,
+      vertical: vertical,
+      horizontal: horizontal,
+      intersection: intersection
+    }
+  end
+
+  def normalize(_other, style), do: normalize(true, style)
+
+  @spec axis_enabled?(t(), :vertical | :horizontal) :: boolean()
+  def axis_enabled?(%__MODULE__{enabled: true, axis: :both}, _axis), do: true
+  def axis_enabled?(%__MODULE__{enabled: true, axis: axis}, axis), do: true
+  def axis_enabled?(_config, _axis), do: false
+
+  @spec visible?(t(), :vertical | :horizontal, non_neg_integer(), non_neg_integer()) :: boolean()
+  def visible?(%__MODULE__{} = config, _axis, content, viewport) do
+    overflow? = content > viewport and viewport > 0
+
+    case config.show do
+      :never -> false
+      :always -> viewport > 0
+      :focus -> overflow?
+      _ -> overflow?
+    end
+  end
+
+  @spec effective_viewport_size(t(), non_neg_integer(), non_neg_integer(), boolean(), boolean()) ::
+          {non_neg_integer(), non_neg_integer()}
+  def effective_viewport_size(%__MODULE__{mode: :inset}, width, height, vertical?, horizontal?) do
+    width = if vertical?, do: max(width - 1, 0), else: width
+    height = if horizontal?, do: max(height - 1, 0), else: height
+    {width, height}
+  end
+
+  def effective_viewport_size(_config, width, height, _vertical?, _horizontal?),
+    do: {width, height}
+
+  @spec placement(t(), :vertical | :horizontal) :: :start | :end
+  def placement(%__MODULE__{} = config, :vertical),
+    do: config.vertical_placement || config.placement
+
+  def placement(%__MODULE__{} = config, :horizontal),
+    do: config.horizontal_placement || config.placement
+
+  @spec thumb_size(t(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  def thumb_size(%__MODULE__{} = config, track_size, content_size) do
+    case config.sizing do
+      {:fixed, size} ->
+        min(max(size, 1), max(track_size, 1))
+
+      _ ->
+        max(
+          min(
+            round(track_size * max(track_size, 1) / max(content_size, 1)),
+            track_size
+          ),
+          min(config.min_thumb_size, max(track_size, 1))
+        )
+    end
+  end
+
+  @spec style_sequence(map()) :: binary()
+  def style_sequence(%Segment{} = segment), do: segment.style
+  def style_sequence(_segment), do: ""
+
+  @spec segment_char(map()) :: binary() | nil
+  def segment_char(%Segment{char: char}), do: char
+  def segment_char(_), do: nil
+
+  defp default(style) do
+    border_color = Map.get(style, :border_color)
+
+    %__MODULE__{
+      enabled: false,
+      vertical: %{
+        track: %Segment{char: "│", foreground_color: border_color},
+        thumb: %Segment{char: "█"},
+        arrow_start: %Segment{char: "▲", foreground_color: border_color},
+        arrow_end: %Segment{char: "▼", foreground_color: border_color}
+      },
+      horizontal: %{
+        track: %Segment{char: "─", foreground_color: border_color},
+        thumb: %Segment{char: "█"},
+        arrow_start: %Segment{char: "◀", foreground_color: border_color},
+        arrow_end: %Segment{char: "▶", foreground_color: border_color}
+      },
+      intersection: %Segment{char: "┼", foreground_color: border_color}
+    }
+    |> renderable_segments()
+  end
+
+  defp normalize_axis(value) when value in @axes, do: value
+  defp normalize_axis(_), do: :vertical
+
+  defp normalize_show(value) when value in @shows, do: value
+  defp normalize_show(_), do: :auto
+
+  defp normalize_mode(value) when value in @modes, do: value
+  defp normalize_mode(_), do: :inset
+
+  defp normalize_placement(value) when value in @placements, do: value
+  defp normalize_placement(_), do: :end
+
+  defp normalize_optional_placement(value) when value in @placements, do: value
+  defp normalize_optional_placement(_), do: nil
+
+  defp normalize_sizing(:proportional), do: :proportional
+
+  defp normalize_sizing({:fixed, value}) do
+    {:fixed, max(normalize_int(value, 1), 1)}
+  end
+
+  defp normalize_sizing(_), do: :proportional
+
+  defp normalize_boolean(value, _default) when is_boolean(value), do: value
+
+  defp normalize_boolean(value, default) when is_binary(value) do
+    case String.downcase(String.trim(value)) do
+      "true" -> true
+      "1" -> true
+      "false" -> false
+      "0" -> false
+      _ -> default
+    end
+  end
+
+  defp normalize_boolean(_value, default), do: default
+
+  defp normalize_int(value, _default) when is_integer(value), do: value
+
+  defp normalize_int(value, default) when is_binary(value) do
+    case Integer.parse(value) do
+      {value, ""} -> value
+      _ -> default
+    end
+  end
+
+  defp normalize_int(_value, default), do: default
+
+  defp normalize_axis_segments(base, common_thumb, common_track, overrides, fallback_color) do
+    thumb =
+      base.thumb
+      |> merge_segment(common_thumb, fallback_color)
+      |> merge_segment(Map.get(overrides, :thumb, %{}), fallback_color)
+      |> merge_segment(overrides, fallback_color)
+      |> segment_to_renderable()
+
+    track =
+      base.track
+      |> merge_segment(common_track, fallback_color)
+      |> merge_segment(Map.get(overrides, :track, %{}), fallback_color)
+      |> segment_to_renderable()
+
+    arrow_start =
+      base.arrow_start
+      |> merge_segment(Map.get(overrides, :arrow_start, %{}), fallback_color)
+      |> segment_to_renderable()
+
+    arrow_end =
+      base.arrow_end
+      |> merge_segment(Map.get(overrides, :arrow_end, %{}), fallback_color)
+      |> segment_to_renderable()
+
+    %{thumb: thumb, track: track, arrow_start: arrow_start, arrow_end: arrow_end}
+  end
+
+  defp merge_segment(%Segment{} = segment, map, fallback_color) when is_map(map) do
+    char = Map.get(map, :char, segment.char)
+
+    segment =
+      %Segment{
+        segment
+        | char: normalize_char(char, segment.char),
+          foreground_color:
+            map
+            |> Map.get(:foreground_color, segment.foreground_color || fallback_color)
+            |> normalize_color(segment.foreground_color || fallback_color),
+          background_color:
+            map
+            |> Map.get(:background_color, segment.background_color)
+            |> normalize_color(segment.background_color),
+          bold: normalize_boolean(Map.get(map, :bold, segment.bold), segment.bold),
+          italic: normalize_boolean(Map.get(map, :italic, segment.italic), segment.italic),
+          reverse: normalize_boolean(Map.get(map, :reverse, segment.reverse), segment.reverse)
+      }
+
+    cond do
+      Map.has_key?(map, :char) and map.char == nil -> %Segment{segment | char: nil}
+      true -> segment
+    end
+  end
+
+  defp merge_segment(%Segment{} = segment, _other, _fallback_color), do: segment
+
+  defp normalize_char(nil, default), do: default
+
+  defp normalize_char(char, _default) when is_binary(char) do
+    char
+    |> String.graphemes()
+    |> List.first()
+  end
+
+  defp normalize_char(_char, default), do: default
+
+  defp normalize_color(nil, default), do: default
+
+  defp normalize_color(value, _default) when is_integer(value) and value >= 0 and value <= 255,
+    do: value
+
+  defp normalize_color(_value, default), do: default
+
+  defp renderable_segments(%__MODULE__{} = config) do
+    %{
+      config
+      | vertical: %{
+          thumb: segment_to_renderable(config.vertical.thumb),
+          track: segment_to_renderable(config.vertical.track),
+          arrow_start: segment_to_renderable(config.vertical.arrow_start),
+          arrow_end: segment_to_renderable(config.vertical.arrow_end)
+        },
+        horizontal: %{
+          thumb: segment_to_renderable(config.horizontal.thumb),
+          track: segment_to_renderable(config.horizontal.track),
+          arrow_start: segment_to_renderable(config.horizontal.arrow_start),
+          arrow_end: segment_to_renderable(config.horizontal.arrow_end)
+        },
+        intersection: segment_to_renderable(config.intersection)
+    }
+  end
+
+  defp segment_to_renderable(%Segment{} = segment) do
+    style =
+      Termite.Style.ansi256()
+      |> maybe_foreground(segment.foreground_color)
+      |> maybe_background(segment.background_color)
+      |> maybe_style(:bold, segment.bold)
+      |> maybe_style(:italic, segment.italic)
+      |> maybe_style(:reverse, segment.reverse)
+
+    token = "§"
+
+    style_prefix =
+      style
+      |> Termite.Style.render_to_string(token)
+      |> String.split(token, parts: 2)
+      |> List.first()
+
+    %{segment | style: style_prefix}
+  end
+
+  defp maybe_foreground(style, nil), do: style
+  defp maybe_foreground(style, color), do: Termite.Style.foreground(style, color)
+
+  defp maybe_background(style, nil), do: style
+  defp maybe_background(style, color), do: Termite.Style.background(style, color)
+
+  defp maybe_style(style, :bold, true), do: Termite.Style.bold(style)
+  defp maybe_style(style, :italic, true), do: Termite.Style.italic(style)
+  defp maybe_style(style, :reverse, true), do: Termite.Style.reverse(style)
+  defp maybe_style(style, _key, _enabled), do: style
+end

--- a/lib/back_breeze/style.ex
+++ b/lib/back_breeze/style.ex
@@ -12,6 +12,7 @@ defmodule BackBreeze.Style do
             width: :auto,
             height: 0,
             overflow: :auto,
+            scrollbar: false,
             border_color: nil,
             foreground_color: nil,
             background_color: nil
@@ -57,6 +58,11 @@ defmodule BackBreeze.Style do
     %{style | overflow: overflow}
   end
 
+  @scrollbars [false, true, :vertical, :horizontal, :both]
+  def scrollbar(style \\ %Style{}, scrollbar \\ true) when scrollbar in @scrollbars do
+    %{style | scrollbar: scrollbar}
+  end
+
   def foreground_color(style \\ %Style{}, color) do
     %{style | foreground_color: color}
   end
@@ -81,6 +87,7 @@ defmodule BackBreeze.Style do
     width = if width == :auto, do: string_length, else: width
     width = if width == :screen, do: screen_width - 2, else: width
     height = if height == :screen, do: screen_height - 2, else: height
+
     str =
       cond do
         string_length <= width -> str

--- a/lib/back_breeze/style.ex
+++ b/lib/back_breeze/style.ex
@@ -59,7 +59,18 @@ defmodule BackBreeze.Style do
   end
 
   @scrollbars [false, true, :vertical, :horizontal, :both]
-  def scrollbar(style \\ %Style{}, scrollbar \\ true) when scrollbar in @scrollbars do
+
+  def scrollbar(style \\ %Style{}, scrollbar \\ true)
+
+  def scrollbar(style, scrollbar) when scrollbar in @scrollbars do
+    %{style | scrollbar: scrollbar}
+  end
+
+  def scrollbar(style, scrollbar) when is_map(scrollbar) do
+    %{style | scrollbar: scrollbar}
+  end
+
+  def scrollbar(style, %BackBreeze.Scrollbar{} = scrollbar) do
     %{style | scrollbar: scrollbar}
   end
 

--- a/test/back_breeze/box_test.exs
+++ b/test/back_breeze/box_test.exs
@@ -210,7 +210,7 @@ defmodule BackBreeze.BoxTest do
                """
                ┌──────┐
                │AAAAAA█
-               │BBBBBB│
+               │BBBBBB█
                │CCCCCC│
                └──────┘\
                """
@@ -232,7 +232,7 @@ defmodule BackBreeze.BoxTest do
                """
                ┌──────┐
                │DDDDDD│
-               │EEEEEE│
+               │EEEEEE█
                │FFFFFF█
                └──────┘\
                """
@@ -251,7 +251,7 @@ defmodule BackBreeze.BoxTest do
       assert rendered.content ==
                """
                ┌──────┐
-               │BBBBBB│
+               │BBBBBB█
                │CCCCCC█
                │DDDDDD│
                └──────┘\
@@ -304,7 +304,7 @@ defmodule BackBreeze.BoxTest do
                """
                ┌──────┐
                █AAAAAA│
-               │BBBBBB│
+               █BBBBBB│
                │CCCCCC│
                └──────┘\
                """
@@ -332,7 +332,49 @@ defmodule BackBreeze.BoxTest do
                ┌─────┐
                │ABCDE│
                │     │
-               └█────┘\
+               └██───┘\
+               """
+    end
+
+    test "scales thumb proportionally by default" do
+      child = BackBreeze.Box.new(content: "AAAAAA\nBBBBBB\nCCCCCC\nDDDDDD\nEEEEEE\nFFFFFF")
+
+      box =
+        BackBreeze.Box.new(
+          style: %{border: :line, width: 6, height: 3, overflow: :hidden, scrollbar: true},
+          children: [child]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      assert String.contains?(rendered.content, "│AAAAAA█")
+      assert String.contains?(rendered.content, "│BBBBBB█")
+    end
+
+    test "supports fixed thumb sizing override" do
+      child = BackBreeze.Box.new(content: "AAAAAA\nBBBBBB\nCCCCCC\nDDDDDD\nEEEEEE\nFFFFFF")
+
+      box =
+        BackBreeze.Box.new(
+          style: %{
+            border: :line,
+            width: 6,
+            height: 3,
+            overflow: :hidden,
+            scrollbar: %{axis: :vertical, sizing: {:fixed, 1}}
+          },
+          children: [child]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      assert rendered.content ==
+               """
+               ┌──────┐
+               │AAAAAA█
+               │BBBBBB│
+               │CCCCCC│
+               └──────┘\
                """
     end
 

--- a/test/back_breeze/box_test.exs
+++ b/test/back_breeze/box_test.exs
@@ -210,7 +210,7 @@ defmodule BackBreeze.BoxTest do
                """
                ┌──────┐
                │AAAAA█│
-               │BBBBB││
+               │BBBBB█│
                │CCCCC││
                └──────┘\
                """
@@ -232,7 +232,7 @@ defmodule BackBreeze.BoxTest do
                """
                ┌──────┐
                │DDDDD││
-               │EEEEE││
+               │EEEEE█│
                │FFFFF█│
                └──────┘\
                """
@@ -251,11 +251,154 @@ defmodule BackBreeze.BoxTest do
       assert rendered.content ==
                """
                ┌──────┐
-               │BBBBB││
+               │BBBBB█│
                │CCCCC█│
                │DDDDD││
                └──────┘\
                """
+    end
+
+    test "supports custom scrollbar chars and colors" do
+      child = BackBreeze.Box.new(content: "AAAAAA\nBBBBBB\nCCCCCC\nDDDDDD\nEEEEEE\nFFFFFF")
+
+      box =
+        BackBreeze.Box.new(
+          style: %{
+            border: :line,
+            width: 6,
+            height: 3,
+            overflow: :hidden,
+            scrollbar: %{
+              axis: :vertical,
+              thumb: %{char: "▓", foreground_color: 2, bold: true},
+              track: %{char: "·", foreground_color: 8}
+            }
+          },
+          children: [child]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      assert String.contains?(rendered.content, "\e[1;38;5;2m▓\e[0m")
+      assert String.contains?(rendered.content, "\e[38;5;8m·\e[0m")
+    end
+
+    test "supports start placement for vertical scrollbars" do
+      child = BackBreeze.Box.new(content: "AAAAAA\nBBBBBB\nCCCCCC\nDDDDDD\nEEEEEE\nFFFFFF")
+
+      box =
+        BackBreeze.Box.new(
+          style: %{
+            border: :line,
+            width: 6,
+            height: 3,
+            overflow: :hidden,
+            scrollbar: %{axis: :vertical, placement: :start}
+          },
+          children: [child]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      assert rendered.content ==
+               """
+               ┌──────┐
+               │█AAAAA│
+               │█BBBBB│
+               ││CCCCC│
+               └──────┘\
+               """
+    end
+
+    test "renders a horizontal scrollbar and thumb" do
+      child = BackBreeze.Box.new(content: "ABCDEFGHIJKL")
+
+      box =
+        BackBreeze.Box.new(
+          style: %{
+            border: :line,
+            width: 5,
+            height: 2,
+            overflow: :hidden,
+            scrollbar: %{axis: :horizontal}
+          },
+          children: [child]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      assert rendered.content ==
+               """
+               ┌─────┐
+               │ABCDE│
+               │██───│
+               └─────┘\
+               """
+    end
+
+    test "respects show: :never" do
+      child = BackBreeze.Box.new(content: "ABCDEFGHIJKL\nMNOPQRSTUVWX\nYZ0123456789")
+
+      box =
+        BackBreeze.Box.new(
+          style: %{
+            border: :line,
+            width: 6,
+            height: 3,
+            overflow: :hidden,
+            scrollbar: %{axis: :both, show: :never, thumb: %{char: "▓"}, track: %{char: "·"}}
+          },
+          children: [child]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      refute String.contains?(rendered.content, "▓")
+      refute String.contains?(rendered.content, "·")
+    end
+
+    test "supports show: :always for non-overflowing content" do
+      child = BackBreeze.Box.new(content: "ABC")
+
+      box =
+        BackBreeze.Box.new(
+          style: %{
+            border: :line,
+            width: 5,
+            height: 2,
+            overflow: :hidden,
+            scrollbar: %{axis: :vertical, show: :always}
+          },
+          children: [child]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+      assert String.contains?(rendered.content, "█")
+    end
+
+    test "renders both scrollbars with arrows" do
+      child = BackBreeze.Box.new(content: "ABCDEFGHIJKL\nMNOPQRSTUVWX\nYZ0123456789\nabcdefghijk")
+
+      box =
+        BackBreeze.Box.new(
+          scroll: {1, 3},
+          style: %{
+            border: :line,
+            width: 6,
+            height: 4,
+            overflow: :hidden,
+            scrollbar: %{axis: :both, arrows: true}
+          },
+          children: [child]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      assert String.contains?(rendered.content, "▲")
+      assert String.contains?(rendered.content, "▼")
+      assert String.contains?(rendered.content, "◀")
+      assert String.contains?(rendered.content, "▶")
+      assert String.contains?(rendered.content, "┼")
     end
   end
 

--- a/test/back_breeze/box_test.exs
+++ b/test/back_breeze/box_test.exs
@@ -194,6 +194,69 @@ defmodule BackBreeze.BoxTest do
                └────────┘\
                """
     end
+
+    test "renders a vertical scrollbar for overflowing child content" do
+      child = BackBreeze.Box.new(content: "AAAAAA\nBBBBBB\nCCCCCC\nDDDDDD\nEEEEEE\nFFFFFF")
+
+      box =
+        BackBreeze.Box.new(
+          style: %{border: :line, width: 6, height: 3, overflow: :hidden, scrollbar: true},
+          children: [child]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      assert rendered.content ==
+               """
+               ┌──────┐
+               │AAAAA█│
+               │BBBBB││
+               │CCCCC││
+               └──────┘\
+               """
+    end
+
+    test "moves scrollbar thumb based on vertical scroll offset" do
+      child = BackBreeze.Box.new(content: "AAAAAA\nBBBBBB\nCCCCCC\nDDDDDD\nEEEEEE\nFFFFFF")
+
+      box =
+        BackBreeze.Box.new(
+          scroll: {3, 0},
+          style: %{border: :line, width: 6, height: 3, overflow: :hidden, scrollbar: true},
+          children: [child]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      assert rendered.content ==
+               """
+               ┌──────┐
+               │DDDDD││
+               │EEEEE││
+               │FFFFF█│
+               └──────┘\
+               """
+    end
+
+    test "renders a vertical scrollbar for overflowing leaf content" do
+      box =
+        BackBreeze.Box.new(
+          content: "AAAAAA\nBBBBBB\nCCCCCC\nDDDDDD\nEEEEEE\nFFFFFF",
+          scroll: {1, 0},
+          style: %{border: :line, width: 6, height: 3, overflow: :hidden, scrollbar: true}
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      assert rendered.content ==
+               """
+               ┌──────┐
+               │BBBBB││
+               │CCCCC█│
+               │DDDDD││
+               └──────┘\
+               """
+    end
   end
 
   describe "join_vertical/2" do

--- a/test/back_breeze/box_test.exs
+++ b/test/back_breeze/box_test.exs
@@ -209,9 +209,9 @@ defmodule BackBreeze.BoxTest do
       assert rendered.content ==
                """
                ┌──────┐
-               │AAAAA█│
-               │BBBBB█│
-               │CCCCC││
+               │AAAAAA█
+               │BBBBBB│
+               │CCCCCC│
                └──────┘\
                """
     end
@@ -231,9 +231,9 @@ defmodule BackBreeze.BoxTest do
       assert rendered.content ==
                """
                ┌──────┐
-               │DDDDD││
-               │EEEEE█│
-               │FFFFF█│
+               │DDDDDD│
+               │EEEEEE│
+               │FFFFFF█
                └──────┘\
                """
     end
@@ -251,9 +251,9 @@ defmodule BackBreeze.BoxTest do
       assert rendered.content ==
                """
                ┌──────┐
-               │BBBBB█│
-               │CCCCC█│
-               │DDDDD││
+               │BBBBBB│
+               │CCCCCC█
+               │DDDDDD│
                └──────┘\
                """
     end
@@ -303,9 +303,9 @@ defmodule BackBreeze.BoxTest do
       assert rendered.content ==
                """
                ┌──────┐
-               │█AAAAA│
-               │█BBBBB│
-               ││CCCCC│
+               █AAAAAA│
+               │BBBBBB│
+               │CCCCCC│
                └──────┘\
                """
     end
@@ -331,8 +331,8 @@ defmodule BackBreeze.BoxTest do
                """
                ┌─────┐
                │ABCDE│
-               │██───│
-               └─────┘\
+               │     │
+               └█────┘\
                """
     end
 
@@ -374,6 +374,54 @@ defmodule BackBreeze.BoxTest do
 
       rendered = BackBreeze.Box.render(box)
       assert String.contains?(rendered.content, "█")
+    end
+
+    test "draws end scrollbar on border gutter for bordered containers" do
+      child = BackBreeze.Box.new(content: "ABCDEF")
+
+      box =
+        BackBreeze.Box.new(
+          style: %{
+            border: :line,
+            width: 6,
+            height: 1,
+            overflow: :hidden,
+            scrollbar: %{axis: :vertical, show: :always}
+          },
+          children: [child]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      assert rendered.content ==
+               """
+               ┌──────┐
+               │ABCDEF█
+               └──────┘\
+               """
+    end
+
+    test "scrollbar thumb reaches the bottom at max vertical scroll" do
+      content = Enum.map_join(1..30, "\n", fn i -> "L#{i}" end)
+
+      box =
+        BackBreeze.Box.new(
+          content: content,
+          scroll: {26, 0},
+          style: %{border: :line, width: 6, height: 4, overflow: :hidden, scrollbar: true}
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      assert rendered.content ==
+               """
+               ┌──────┐
+               │L27   │
+               │L28   │
+               │L29   │
+               │L30   █
+               └──────┘\
+               """
     end
 
     test "renders both scrollbars with arrows" do

--- a/test/back_breeze/box_test.exs
+++ b/test/back_breeze/box_test.exs
@@ -488,7 +488,70 @@ defmodule BackBreeze.BoxTest do
       assert String.contains?(rendered.content, "▼")
       assert String.contains?(rendered.content, "◀")
       assert String.contains?(rendered.content, "▶")
-      assert String.contains?(rendered.content, "┼")
+      assert String.contains?(rendered.content, "┘")
+    end
+
+    test "vertical arrows are not trimmed when horizontal scrollbar sits on the bottom border" do
+      child = BackBreeze.Box.new(content: Enum.map_join(1..8, "\n", fn _ -> "ABCDEFGHIJKL" end))
+
+      box =
+        BackBreeze.Box.new(
+          style: %{
+            border: :line,
+            width: 6,
+            height: 4,
+            overflow: :hidden,
+            scrollbar: %{axis: :both, arrows: true}
+          },
+          children: [child]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+      rows = String.split(rendered.content, "\n")
+
+      assert String.ends_with?(Enum.at(rows, 1), "▲")
+      assert String.ends_with?(Enum.at(rows, 4), "▼")
+    end
+
+    test "horizontal arrows are not trimmed when vertical scrollbar sits on the right border" do
+      child = BackBreeze.Box.new(content: Enum.map_join(1..8, "\n", fn _ -> "ABCDEFGHIJKL" end))
+
+      box =
+        BackBreeze.Box.new(
+          style: %{
+            border: :line,
+            width: 6,
+            height: 4,
+            overflow: :hidden,
+            scrollbar: %{axis: :both, arrows: true}
+          },
+          children: [child]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+      rows = String.split(rendered.content, "\n")
+
+      assert String.ends_with?(Enum.at(rows, 5), "▶┘")
+    end
+
+    test "supports colored horizontal scrollbar" do
+      child = BackBreeze.Box.new(content: "ABCDEFGH")
+
+      box =
+        BackBreeze.Box.new(
+          style: %{
+            border: :line,
+            width: 5,
+            height: 2,
+            overflow: :hidden,
+            scrollbar: %{axis: :horizontal, thumb: %{foreground_color: 2}, track: %{foreground_color: 8}}
+          },
+          children: [child]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+      assert String.contains?(rendered.content, "\e[38;5;2m███\e[0m")
+      assert String.contains?(rendered.content, "\e[38;5;8m──\e[0m")
     end
   end
 

--- a/test/back_breeze/style_test.exs
+++ b/test/back_breeze/style_test.exs
@@ -21,6 +21,16 @@ defmodule BackBreeze.StyleTest do
       assert BackBreeze.Style.scrollbar(%BackBreeze.Style{}, :horizontal).scrollbar == :horizontal
       assert BackBreeze.Style.scrollbar(%BackBreeze.Style{}, :both).scrollbar == :both
       assert BackBreeze.Style.scrollbar(%BackBreeze.Style{}, false).scrollbar == false
+
+      style =
+        BackBreeze.Style.scrollbar(%BackBreeze.Style{}, %{
+          axis: :both,
+          thumb: %{char: "▓", foreground_color: 2},
+          track: %{char: "·", foreground_color: 8}
+        })
+
+      assert is_map(style.scrollbar)
+      assert style.scrollbar.axis == :both
     end
 
     test "outputting the styles" do

--- a/test/back_breeze/style_test.exs
+++ b/test/back_breeze/style_test.exs
@@ -15,6 +15,14 @@ defmodule BackBreeze.StyleTest do
       assert style.foreground_color == 3
     end
 
+    test "supports scrollbar style values" do
+      assert BackBreeze.Style.scrollbar().scrollbar == true
+      assert BackBreeze.Style.scrollbar(%BackBreeze.Style{}, :vertical).scrollbar == :vertical
+      assert BackBreeze.Style.scrollbar(%BackBreeze.Style{}, :horizontal).scrollbar == :horizontal
+      assert BackBreeze.Style.scrollbar(%BackBreeze.Style{}, :both).scrollbar == :both
+      assert BackBreeze.Style.scrollbar(%BackBreeze.Style{}, false).scrollbar == false
+    end
+
     test "outputting the styles" do
       style =
         BackBreeze.Style.bold()


### PR DESCRIPTION
- add `BackBreeze.Style.scrollbar/2` with backward-compatible shorthands (`false | true | :vertical | :horizontal | :both`)
- add `BackBreeze.Scrollbar` config normalization + rendering helpers
- support configurable scrollbar options: axis/show/mode/placement/arrows/min thumb size/sizing
- support both vertical and horizontal scrollbars (and combined intersection rendering)
- support configurable thumb/track chars and ANSI styling (foreground/background/bold/italic/reverse)
- support rendering for both leaf boxes and boxes with children
- keep behavior unchanged by default (scrollbar off)
- update docs + overflow example and expand coverage for configurable behavior

Tests: `mix test` (58 tests, 0 failures).