### PR TITLE
fix(BackBreeze.Box): fix sizing calculations when building tree

### DIFF
--- a/lib/back_breeze/box.ex
+++ b/lib/back_breeze/box.ex
@@ -18,7 +18,8 @@ defmodule BackBreeze.Box do
             display: :block,
             scroll: {0, 0},
             layer: 0,
-            layer_map: %{}
+            layer_map: %{},
+            overlay?: false
 
   @doc """
   Create a new `BackBreeze.Box` struct.
@@ -122,6 +123,7 @@ defmodule BackBreeze.Box do
       box
       | content: content,
         width: width,
+        height: dimensions.height,
         state: :rendered,
         children: [],
         layer_map: layer_map
@@ -135,22 +137,36 @@ defmodule BackBreeze.Box do
 
     child_length = length(box.children)
 
-    {child_layer_map, child_width, child_height, acc} =
+    {child_layer_map, child_width, child_height, has_overlay_children?, child_layer, acc} =
       render_children(%{acc | id: prev_id + 1}, opts)
 
     style_width = if box.style.width == :auto, do: 0, else: box.style.width
 
     width =
-      if box.style.overflow == :hidden,
-        do: box.style.width,
-        else: max(style_width, child_width)
+      cond do
+        box.style.overflow == :hidden ->
+          box.style.width
+
+        is_integer(box.style.width) and box.style.width > 0 ->
+          box.style.width
+
+        true ->
+          max(style_width, child_width)
+      end
 
     style_height = if box.style.height == :auto, do: 0, else: box.style.height
 
     height =
-      if box.style.overflow == :hidden,
-        do: box.style.height,
-        else: max(style_height, child_height)
+      cond do
+        box.style.overflow == :hidden ->
+          box.style.height
+
+        is_integer(box.style.height) and box.style.height > 0 ->
+          box.style.height
+
+        true ->
+          max(style_height, child_height)
+      end
 
     style = %{box.style | width: width, height: height}
 
@@ -178,9 +194,24 @@ defmodule BackBreeze.Box do
         end
       )
 
+    dimensions =
+      if box.style.height in [:auto, :full] ||
+           (is_integer(box.style.height) && box.style.height <= 0 && box.style.width != :screen) do
+        resolved_height = max(dimensions.height, dimensions.content_height)
+
+        %{
+          dimensions
+          | height: resolved_height,
+            viewport_height: max(dimensions.viewport_height, resolved_height - border_rows)
+        }
+      else
+        dimensions
+      end
+
     acc = %{acc | dimensions: [{prev_id, dimensions} | acc.dimensions], id: acc.id}
 
     {layer_map, max_width, max_height} = generate_layer_map(content, %{}, 0, 0)
+    max_height = max(max_height, max(rendered_height(content) - 1, 0))
 
     {_, offset_left} = box.scroll
 
@@ -191,13 +222,38 @@ defmodule BackBreeze.Box do
         child_layer_map
       end
 
-    child_layer_map = clip_child_layer_map(child_layer_map, box.style, max_width, max_height)
+    clip_relative_children? =
+      box.style.overflow == :hidden ||
+        (is_integer(box.style.height) && box.style.height > 0 && !has_overlay_children?)
 
-    {max_width, max_height} =
-      if box.style.overflow == :hidden do
-        {max_width, max_height}
+    child_layer_map =
+      if clip_relative_children? do
+        clip_child_layer_map(child_layer_map, box.style, max_width, max_height)
       else
-        {max(max_width, child_width), max(max_height, child_height)}
+        child_layer_map
+      end
+
+    max_width =
+      if box.style.overflow == :hidden do
+        max_width
+      else
+        max(max_width, child_width)
+      end
+
+    max_height =
+      cond do
+        box.style.overflow == :hidden ->
+          max_height
+
+        box.style.height in [:auto, :full] ||
+            (is_integer(box.style.height) && box.style.height <= 0) ->
+          max(max_height, child_height)
+
+        has_overlay_children? ->
+          max(max_height, child_height)
+
+        true ->
+          max_height
       end
 
     child_layer_map =
@@ -210,16 +266,10 @@ defmodule BackBreeze.Box do
         max_y: max_height
       })
 
-    {start_x, start_y} =
-      case box.position do
-        :absolute -> {box.left, box.top}
-        _ -> {0, 0}
-      end
-
     content =
       layer_maps_to_content(layer_map, child_layer_map, %{
-        start_x: start_x,
-        start_y: start_y,
+        start_x: 0,
+        start_y: 0,
         max_x: max_width,
         max_y: max_height
       })
@@ -228,8 +278,11 @@ defmodule BackBreeze.Box do
       box
       | content: content,
         width: max_width + 1,
+        height: max_height + 1,
+        layer: max(box.layer || 0, child_layer || 0),
         state: :rendered,
-        layer_map: Map.merge(layer_map, child_layer_map)
+        layer_map: Map.merge(layer_map, child_layer_map),
+        overlay?: has_overlay_children?
     }
 
     %{acc | box: box}
@@ -252,15 +305,30 @@ defmodule BackBreeze.Box do
          %{box: %{children: children, display: %BackBreeze.Grid{}} = box} = acc,
          opts
        ) do
-    %{width: item_width} = BackBreeze.Grid.precompute(children, box.display, box.style, opts)
+    %{
+      width: item_width,
+      height: item_height,
+      column_widths: column_widths,
+      row_heights: row_heights
+    } =
+      BackBreeze.Grid.precompute(children, box.display, box.style, opts)
 
     {children, grouped_dims} =
-      Enum.reduce(children, {[], []}, fn
-        %{display: %BackBreeze.Grid{}, children: children} = child_box, child_acc
+      children
+      |> Enum.with_index()
+      |> Enum.reduce({[], []}, fn
+        {%{display: %BackBreeze.Grid{}, children: children} = child_box, child_index}, child_acc
         when children != [] ->
-          style = %{child_box.style | width: item_width}
+          row_index = div(child_index, box.display.columns)
+          col_index = rem(child_index, box.display.columns)
 
-          %{content: content, width: w, height: h, dimensions: inner_dimensions} =
+          style = %{
+            child_box.style
+            | width: Enum.at(column_widths, col_index, item_width),
+              height: Enum.at(row_heights, row_index, item_height)
+          }
+
+          %{content: content, width: w, height: h, per_item_dimensions: inner_dimensions} =
             BackBreeze.Grid.render_with_dimensions(
               child_box.children,
               child_box.display,
@@ -276,24 +344,34 @@ defmodule BackBreeze.Box do
               content: content,
               width: w,
               height: h,
-              state: :rendered
+              state: :rendered,
+              overlay?:
+                rendered_height(content) > max(h || 0, 0) ||
+                  contains_absolute_descendants?(child_box)
           }
 
           container_dim = %{content_height: h, viewport_height: h, height: h}
-          {children ++ [child], dims ++ [[container_dim | inner_dimensions]]}
+          {children ++ [child], dims ++ [[container_dim | List.flatten(inner_dimensions)]]}
 
-        child_box, child_acc ->
+        {child_box, _child_index}, child_acc ->
           {children, dims} = child_acc
           {children ++ [child_box], dims ++ [nil]}
       end)
 
     children = set_layer(children, [], -1)
 
+    has_overlay_children? =
+      Enum.any?(
+        children,
+        &(&1.position == :absolute || &1.overlay? || contains_absolute_descendants?(&1))
+      )
+
     relative = Enum.filter(children, &(&1.position != :absolute))
 
     {layer, style} =
-      case relative do
-        [x | _] -> {x.layer, x.style}
+      case {children, relative} do
+        {[%{} | _], [x | _]} -> {Enum.max(Enum.map(children, & &1.layer)), x.style}
+        {[%{} | _], _} -> {Enum.max(Enum.map(children, & &1.layer)), %BackBreeze.Style{}}
         _ -> {0, %BackBreeze.Style{}}
       end
 
@@ -323,32 +401,24 @@ defmodule BackBreeze.Box do
         children: [],
         height: height,
         width: width,
-        layer: layer
+        layer: layer,
+        position: :relative,
+        left: nil,
+        top: nil
     }
 
-    combine_children(box, absolutes, relative, acc)
+    {layer_map, width, height, acc} = combine_children(box, absolutes, relative, acc)
+    {layer_map, width, height, has_overlay_children?, layer, acc}
   end
 
   defp render_children(%{box: %{children: children} = box} = acc, opts) when children != [] do
-    # Mirror BackBreeze.Style.calculate_and_render/3, which resolves :screen to the
-    # terminal size minus the outer frame.
-    parent_width =
-      case box.style.width do
-        w when is_integer(w) -> w
-        :screen -> opts |> Keyword.get(:terminal) |> BackBreeze.screen_dimensions() |> elem(0) |> Kernel.-(2)
-        _ -> nil
-      end
-
-    parent_height =
-      case box.style.height do
-        h when is_integer(h) -> h
-        :screen -> opts |> Keyword.get(:terminal) |> BackBreeze.screen_dimensions() |> elem(1) |> Kernel.-(2)
-        _ -> nil
-      end
+    parent_width = resolved_parent_width(box, opts)
+    parent_height = resolved_parent_height(box, opts)
 
     {children, acc, _used_height} =
       set_layer(children, [], -1)
-      |> resolve_fill_widths(parent_width)
+      |> Enum.map(&resolve_absolute_fill_offsets(&1, box.style.border))
+      |> resolve_fill_widths(parent_width, box.display)
       |> Enum.reduce({[], acc, 0}, fn child, {boxes, child_acc, used_height} ->
         child = resolve_fill_height(child, box.display, parent_height, used_height)
         child_acc = render_and_calc(%{child_acc | box: child}, opts)
@@ -364,20 +434,36 @@ defmodule BackBreeze.Box do
       end)
 
     children = Enum.reverse(children)
+    has_overlay_children? = Enum.any?(children, &(&1.position == :absolute || &1.overlay?))
 
     relative =
       children
       |> Enum.filter(&(&1.position != :absolute))
 
     {layer, style} =
-      case relative do
-        [x | _] -> {x.layer, x.style}
+      case {children, relative} do
+        {[%{} | _], [x | _]} -> {Enum.max(Enum.map(children, & &1.layer)), x.style}
+        {[%{} | _], _} -> {Enum.max(Enum.map(children, & &1.layer)), %BackBreeze.Style{}}
         _ -> {0, %BackBreeze.Style{}}
       end
 
     items = Enum.map(relative, & &1.content)
 
-    opts = Keyword.put(opts, :height, box.style.height)
+    relative_has_overlay? =
+      Enum.any?(relative, fn child ->
+        child.overlay? || rendered_height(child.content) > max(child.height || 0, 0)
+      end)
+
+    resolved_join_height =
+      cond do
+        box.display == :block && relative_has_overlay? && box.style.overflow != :hidden ->
+          nil
+
+        true ->
+          box.style.height
+      end
+
+    opts = Keyword.put(opts, :height, resolved_join_height)
     opts = Keyword.put(opts, :scroll, box.scroll)
 
     {content, width, height} =
@@ -395,10 +481,14 @@ defmodule BackBreeze.Box do
         children: [],
         height: height,
         width: width,
-        layer: layer
+        layer: layer,
+        position: :relative,
+        left: nil,
+        top: nil
     }
 
-    combine_children(box, absolutes, relative, acc)
+    {layer_map, width, height, acc} = combine_children(box, absolutes, relative, acc)
+    {layer_map, width, height, has_overlay_children?, layer, acc}
   end
 
   defp combine_children(box, absolutes, relative, acc) do
@@ -416,10 +506,41 @@ defmodule BackBreeze.Box do
           _ -> {1, 1}
         end
 
-      {map, width, height} = generate_layer_map(box.content, layer_map, start_x, y)
+      {map, width, height} =
+        cond do
+          box.position == :absolute && map_size(box.layer_map) > 0 ->
+            merge_layer_map(layer_map, box.layer_map, start_x, y)
+
+          true ->
+            generate_layer_map(box.content, layer_map, start_x, y)
+        end
 
       {map, max(max_width, width), max(max_height, height), acc}
     end)
+  end
+
+  defp merge_layer_map(target_map, source_map, offset_x, offset_y) do
+    {map, max_x, max_y} =
+      Enum.reduce(source_map, {target_map, 0, 0}, fn
+        {{_y, _x}, {" ", ""}}, acc ->
+          acc
+
+        {{y, x}, {char, _} = value}, {acc, cur_max_x, cur_max_y} ->
+          shifted_x = x + offset_x
+          shifted_y = y + offset_y
+          width = Ucwidth.width(char)
+
+          {
+            Map.put(acc, {shifted_y, shifted_x}, value),
+            max(cur_max_x, shifted_x + width - 1),
+            max(cur_max_y, shifted_y)
+          }
+
+        _, acc ->
+          acc
+      end)
+
+    {map, max_x, max_y}
   end
 
   defp generate_layer_map(content, layer_map, start_x, y) do
@@ -486,7 +607,7 @@ defmodule BackBreeze.Box do
         end
       end)
 
-    Enum.join(content, "\n") |> String.trim_trailing("\n")
+    Enum.join(content, "\n")
   end
 
   defp clip_child_layer_map(layer_map, %{overflow: :hidden, border: border}, max_x, max_y)
@@ -545,14 +666,59 @@ defmodule BackBreeze.Box do
 
   defp rendered_height(_), do: 0
 
-  defp resolve_fill_widths(children, nil), do: children
+  defp resolved_parent_width(%{style: %{width: width, border: border}}, opts) do
+    case width do
+      w when is_integer(w) ->
+        w
 
-  defp resolve_fill_widths(children, parent_width) do
+      :screen ->
+        {screen_width, _screen_height} =
+          BackBreeze.screen_dimensions(Keyword.get(opts, :terminal))
+
+        max(screen_width - border_horizontal(border), 0)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp resolved_parent_height(%{style: %{height: height, border: border}}, opts) do
+    case height do
+      h when is_integer(h) ->
+        h
+
+      :screen ->
+        {_screen_width, screen_height} =
+          BackBreeze.screen_dimensions(Keyword.get(opts, :terminal))
+
+        max(screen_height - border_vertical(border), 0)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp border_horizontal(border),
+    do: if(border.left, do: 1, else: 0) + if(border.right, do: 1, else: 0)
+
+  defp border_vertical(border),
+    do: if(border.top, do: 1, else: 0) + if(border.bottom, do: 1, else: 0)
+
+  defp resolve_fill_widths(children, nil, _display), do: children
+
+  defp resolve_fill_widths(children, parent_width, display) do
     Enum.map(children, fn child ->
-      if child.style.width == :full do
-        border_adj =
-          if(child.style.border.left, do: 1, else: 0) +
-            if child.style.border.right, do: 1, else: 0
+      auto_fill_container? =
+        display == :block &&
+          child.style.width == :auto &&
+          (match?(%BackBreeze.Grid{}, child.display) || child.children != [])
+
+      should_fill_width? =
+        child.style.width == :full ||
+          (child.position != :absolute && auto_fill_container?)
+
+      if should_fill_width? do
+        border_adj = border_horizontal(child.style.border)
 
         %{child | style: %{child.style | width: max(0, parent_width - border_adj)}}
       else
@@ -565,9 +731,7 @@ defmodule BackBreeze.Box do
 
   defp resolve_fill_height(child, :inline, parent_height, _used_height) do
     if child.style.height == :full do
-      border_adj =
-        if(child.style.border.top, do: 1, else: 0) +
-          if(child.style.border.bottom, do: 1, else: 0)
+      border_adj = border_vertical(child.style.border)
 
       %{child | style: %{child.style | height: max(0, parent_height - border_adj)}}
     else
@@ -576,23 +740,54 @@ defmodule BackBreeze.Box do
   end
 
   defp resolve_fill_height(child, :block, parent_height, used_height) do
-    if child.position == :absolute or child.style.height != :full do
+    if child.style.height != :full do
       child
     else
-      border_adj =
-        if(child.style.border.top, do: 1, else: 0) +
-          if(child.style.border.bottom, do: 1, else: 0)
+      border_adj = border_vertical(child.style.border)
 
+      used_height = if child.position == :absolute, do: 0, else: used_height
       %{child | style: %{child.style | height: max(0, parent_height - used_height - border_adj)}}
     end
   end
+
+  defp resolve_absolute_fill_offsets(
+         %{position: :absolute, style: %{width: :full, height: :full}} = child,
+         border
+       ) do
+    %{
+      child
+      | left: default_fill_offset(child.left, border.left),
+        top: default_fill_offset(child.top, border.top)
+    }
+  end
+
+  defp resolve_absolute_fill_offsets(
+         %{position: :absolute, style: %{width: :full}} = child,
+         border
+       ) do
+    %{child | left: default_fill_offset(child.left, border.left)}
+  end
+
+  defp resolve_absolute_fill_offsets(
+         %{position: :absolute, style: %{height: :full}} = child,
+         border
+       ) do
+    %{child | top: default_fill_offset(child.top, border.top)}
+  end
+
+  defp resolve_absolute_fill_offsets(child, _border), do: child
+
+  defp default_fill_offset(nil, edge), do: if(edge, do: 1, else: 0)
+  defp default_fill_offset(0, edge), do: if(edge, do: 1, else: 0)
+  defp default_fill_offset(offset, _edge), do: offset
 
   defp set_layer([], result, _layer) do
     Enum.reverse(result)
   end
 
   defp set_layer([%{position: :absolute} = box | rest], result, layer) do
-    set_layer(rest, [%{box | layer: layer + 1} | result], layer + 2)
+    next_layer = max(layer + 1, box.layer || layer + 1)
+    set_layer(rest, [%{box | layer: next_layer} | result], next_layer + 1)
   end
 
   defp set_layer([box | rest], result, layer) when is_binary(box) do
@@ -600,12 +795,22 @@ defmodule BackBreeze.Box do
   end
 
   defp set_layer([box | rest], result, nil) do
-    set_layer(rest, [%{box | layer: 0} | result], 0)
+    next_layer = box.layer || 0
+    set_layer(rest, [%{box | layer: next_layer} | result], next_layer)
   end
 
   defp set_layer([box | rest], result, layer) do
-    set_layer(rest, [%{box | layer: layer} | result], layer)
+    next_layer = box.layer || layer
+    set_layer(rest, [%{box | layer: next_layer} | result], next_layer)
   end
+
+  defp contains_absolute_descendants?(%{position: :absolute}), do: true
+
+  defp contains_absolute_descendants?(%{children: children}) when is_list(children) do
+    Enum.any?(children, &contains_absolute_descendants?/1)
+  end
+
+  defp contains_absolute_descendants?(_), do: false
 
   @doc false
   def join_vertical(items, opts \\ [])
@@ -628,7 +833,6 @@ defmodule BackBreeze.Box do
     items =
       items
       |> Enum.join("\n")
-      |> String.trim_trailing("\n")
       |> String.split("\n")
 
     items =
@@ -637,7 +841,7 @@ defmodule BackBreeze.Box do
           {_screen_width, screen_height} =
             BackBreeze.screen_dimensions(Keyword.get(opts, :terminal))
 
-          height = screen_height - 2
+          height = screen_height
 
           # TODO: swap X and Y obviously
           {start_pos, _} = Keyword.get(opts, :scroll, {0, 0})
@@ -684,7 +888,6 @@ defmodule BackBreeze.Box do
     content =
       rows
       |> Enum.join("\n")
-      |> String.trim_trailing("\n")
 
     {content, width, max_height}
   end

--- a/lib/back_breeze/grid.ex
+++ b/lib/back_breeze/grid.ex
@@ -14,7 +14,7 @@ defmodule BackBreeze.Grid do
   """
   defstruct [:columns, :rows]
 
-  @auto_sizes [:screen, :auto]
+  @auto_sizes [:screen, :auto, :full]
 
   @doc false
   def precompute(items, grid, style, opts) do
@@ -38,11 +38,15 @@ defmodule BackBreeze.Grid do
 
     rows = Enum.chunk_every(items, grid.columns)
     row_count = grid.rows || length(rows)
+    column_widths = resolve_track_sizes(rows, grid.columns, width - width_offset, :width)
+    row_heights = resolve_track_sizes(rows, row_count, height - height_offset, :height)
 
-    item_width = div(width - width_offset, grid.columns)
-    item_height = div(height - height_offset, row_count)
-
-    %{width: item_width, height: item_height}
+    %{
+      width: Enum.min(column_widths, fn -> 0 end),
+      height: Enum.max(row_heights, fn -> 0 end),
+      column_widths: column_widths,
+      row_heights: row_heights
+    }
   end
 
   @doc false
@@ -62,16 +66,16 @@ defmodule BackBreeze.Grid do
     # Although this is similar to the calculation in precompute, dividing into columns happens
     # only if the width is not explicitly specified, compared to always dividing in the
     # precompute function
-    item_width =
-      case style.width do
-        width when width in @auto_sizes -> div(screen_width - width_offset, grid.columns)
-        other -> other
-      end
-
     height_offset = if(style.border.top, do: 1, else: 0) + if style.border.bottom, do: 1, else: 0
 
     rows = Enum.chunk_every(items, grid.columns)
     row_count = grid.rows || length(rows)
+
+    total_width =
+      case style.width do
+        width when width in @auto_sizes -> screen_width - width_offset
+        other -> other
+      end
 
     total_height =
       case style.height do
@@ -79,32 +83,180 @@ defmodule BackBreeze.Grid do
         _ -> screen_height - height_offset
       end
 
-    base_height = div(total_height, row_count)
-    remainder = rem(total_height, row_count)
+    column_widths = resolve_track_sizes(rows, grid.columns, total_width, :width)
+    row_heights = resolve_track_sizes(rows, row_count, total_height, :height)
 
     rows_with_results =
       rows
       |> Enum.with_index()
       |> Enum.map(fn {cols, row_index} ->
-        row_height = base_height + if(row_index < remainder, do: 1, else: 0)
+        row_height = Enum.at(row_heights, row_index, 0)
 
-        Enum.map(cols, fn %{style: %{border: border}} = item ->
-          width = item_width - if(border.left, do: 1, else: 0) - if border.right, do: 1, else: 0
+        cols
+        |> Enum.with_index()
+        |> Enum.map(fn {%{style: %{border: border}} = item, col_index} ->
+          col_width = Enum.at(column_widths, col_index, 0)
+
+          width = col_width - if(border.left, do: 1, else: 0) - if border.right, do: 1, else: 0
           height = row_height - if(border.top, do: 1, else: 0) - if border.bottom, do: 1, else: 0
 
-          style = %{item.style | width: width, height: height, overflow: :hidden}
-          BackBreeze.Box.render_with_dimensions(%{item | style: style})
+          style = %{item.style | width: max(width, 0), height: max(height, 0)}
+
+          %{
+            item: item,
+            result: BackBreeze.Box.render_with_dimensions(%{item | style: style})
+          }
         end)
       end)
 
     per_item_dimensions =
-      Enum.flat_map(rows_with_results, fn row -> Enum.map(row, & &1.dimensions) end)
+      Enum.flat_map(rows_with_results, fn row -> Enum.map(row, & &1.result.dimensions) end)
 
-    rows_with_results
-    |> Enum.map(&BackBreeze.Joiner.new/1)
-    |> Enum.map(&BackBreeze.Joiner.join_horizontal/1)
-    |> BackBreeze.Joiner.merge()
-    |> BackBreeze.Joiner.join_vertical()
-    |> Map.put(:per_item_dimensions, per_item_dimensions)
+    children =
+      rows_with_results
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {row, row_index} ->
+        top = Enum.take(row_heights, row_index) |> Enum.sum()
+
+        row
+        |> Enum.with_index()
+        |> Enum.map(fn {%{item: item, result: %{box: item_box}}, col_index} ->
+          left = Enum.take(column_widths, col_index) |> Enum.sum()
+
+          overlay? = item_box.overlay? || contains_absolute_descendants?(item)
+
+          layer =
+            if overlay? do
+              max(item_box.layer || 0, 1)
+            else
+              item_box.layer || 0
+            end
+
+          %{
+            item_box
+            | position: :absolute,
+              left: left,
+              top: top,
+              layer: layer,
+              overlay?: overlay?
+          }
+        end)
+      end)
+      |> Enum.sort_by(fn child -> {child.overlay?, child.top || 0, child.left || 0} end)
+
+    %{
+      box: %{content: content, width: rendered_width, height: rendered_height}
+    } =
+      BackBreeze.Box.render_with_dimensions(
+        BackBreeze.Box.new(children: children, style: %{width: total_width})
+      )
+
+    %{
+      content: content,
+      width: max(total_width, rendered_width || total_width),
+      height: max(total_height, rendered_height || total_height),
+      per_item_dimensions: per_item_dimensions
+    }
   end
+
+  defp resolve_track_sizes(rows, track_count, total, axis) do
+    explicit =
+      case axis do
+        :width ->
+          0..(track_count - 1)
+          |> Enum.map(fn track_index ->
+            rows
+            |> Enum.map(&Enum.at(&1, track_index))
+            |> Enum.reject(&is_nil/1)
+            |> Enum.map(&explicit_track_size(&1, axis))
+            |> Enum.reject(&is_nil/1)
+            |> Enum.max(fn -> nil end)
+          end)
+
+        :height ->
+          rows
+          |> Enum.take(track_count)
+          |> Enum.map(fn row ->
+            row
+            |> Enum.map(&explicit_track_size(&1, axis))
+            |> Enum.reject(&is_nil/1)
+            |> Enum.max(fn -> nil end)
+          end)
+      end
+
+    grow_indexes =
+      explicit
+      |> Enum.with_index()
+      |> Enum.flat_map(fn
+        {nil, index} -> [index]
+        _ -> []
+      end)
+
+    distribute_dimension(track_count, max(total, 0), explicit, grow_indexes)
+  end
+
+  defp explicit_track_size(item, axis) do
+    case item do
+      %{style: style} ->
+        style_value = Map.get(style, axis)
+        border_size = border_size(style.border, axis)
+
+        case style_value do
+          value when is_integer(value) and value > 0 -> value + border_size
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp border_size(border, :width),
+    do: if(border.left, do: 1, else: 0) + if(border.right, do: 1, else: 0)
+
+  defp border_size(border, :height),
+    do: if(border.top, do: 1, else: 0) + if(border.bottom, do: 1, else: 0)
+
+  defp distribute_dimension(count, total, explicit, grow_indexes) do
+    explicit_total =
+      explicit
+      |> Enum.reject(&is_nil/1)
+      |> Enum.sum()
+
+    remainder = max(total - explicit_total, 0)
+
+    grow_sizes =
+      if grow_indexes == [] do
+        base = div(total, max(count, 1))
+        extra = rem(total, max(count, 1))
+
+        0..(count - 1)
+        |> Enum.map(fn index -> base + if(index < extra, do: 1, else: 0) end)
+      else
+        base = div(remainder, length(grow_indexes))
+        extra = rem(remainder, length(grow_indexes))
+
+        grow_indexes
+        |> Enum.with_index()
+        |> Map.new(fn {track_index, index} ->
+          {track_index, base + if(index < extra, do: 1, else: 0)}
+        end)
+      end
+
+    explicit
+    |> Enum.with_index()
+    |> Enum.map(fn
+      {nil, index} when is_map(grow_sizes) -> Map.get(grow_sizes, index, 0)
+      {nil, index} -> Enum.at(grow_sizes, index, 0)
+      {value, _index} -> value
+    end)
+  end
+
+  defp contains_absolute_descendants?(%{position: :absolute}), do: true
+
+  defp contains_absolute_descendants?(%{children: children}) when is_list(children) do
+    Enum.any?(children, &contains_absolute_descendants?/1)
+  end
+
+  defp contains_absolute_descendants?(_), do: false
 end

--- a/lib/back_breeze/style.ex
+++ b/lib/back_breeze/style.ex
@@ -130,9 +130,13 @@ defmodule BackBreeze.Style do
     {height, style} = Map.pop(style, :height, 0)
 
     auto_width = width in [:auto, :full]
+    border_width = if(border.left, do: 1, else: 0) + if(border.right, do: 1, else: 0)
+    border_height = if(border.top, do: 1, else: 0) + if(border.bottom, do: 1, else: 0)
+
     width = if width in [:auto, :full], do: string_length, else: width
-    width = if width == :screen, do: screen_width - 2, else: width
-    height = if height == :screen, do: screen_height - 2, else: height
+    width = if width == :screen, do: screen_width - border_width, else: width
+    height = if height == :full, do: 0, else: height
+    height = if height == :screen, do: screen_height - border_height, else: height
 
     str =
       cond do
@@ -144,7 +148,12 @@ defmodule BackBreeze.Style do
     termite_style = to_termite(style)
 
     border = %{border | color: style.border_color}
-    lines = String.split(str, "\n")
+
+    lines =
+      case String.split(str, "\n") do
+        [""] -> []
+        other -> other
+      end
 
     content_height = if List.last(lines) == "", do: length(lines) - 1, else: length(lines)
     original_height = height
@@ -159,42 +168,43 @@ defmodule BackBreeze.Style do
 
     lines = Enum.slice(lines, start_pos..end_pos//1)
 
-    content =
-      Enum.reduce(lines, "", fn line, acc ->
+    rendered_rows =
+      Enum.map(lines, fn line ->
         string_length = BackBreeze.Utils.string_length(line)
         string_padding = if width > string_length, do: width - string_length, else: 0
 
-        acc <>
-          BackBreeze.Border.render_left(border) <>
+        BackBreeze.Border.render_left(border) <>
           Termite.Style.render_to_string(
             termite_style,
             line <> String.duplicate(" ", string_padding)
           ) <>
-          BackBreeze.Border.render_right(border) <> "\n"
+          BackBreeze.Border.render_right(border)
       end)
 
-    line_length = length(lines)
-    height = if line_length > height, do: 0, else: height + 1 - line_length
+    line_count = length(lines)
 
-    padding =
-      if height > 1 do
-        Enum.reduce(1..(height - 1), "", fn _i, acc ->
-          acc <>
+    padding_rows =
+      case height - line_count do
+        remaining when remaining > 0 ->
+          Enum.map(1..remaining, fn _i ->
             BackBreeze.Border.render_left(border) <>
-            String.duplicate(" ", width) <>
-            BackBreeze.Border.render_right(border) <> "\n"
-        end)
-      else
-        ""
+              Termite.Style.render_to_string(termite_style, String.duplicate(" ", width)) <>
+              BackBreeze.Border.render_right(border)
+          end)
+
+        _ ->
+          []
       end
 
-    content =
-      BackBreeze.Border.render_top(border, width) <>
-        String.trim_trailing(content, "\n") <>
-        if(padding != "" || border.bottom, do: "\n", else: "") <>
-        padding <> BackBreeze.Border.render_bottom(border, width)
+    rows =
+      []
+      |> maybe_append_row(BackBreeze.Border.render_top(border, width))
+      |> Kernel.++(rendered_rows)
+      |> Kernel.++(padding_rows)
+      |> maybe_append_row(BackBreeze.Border.render_bottom(border, width))
 
-    height = String.split(content, "\n") |> length()
+    content = Enum.join(rows, "\n")
+    height = length(rows)
 
     viewport_height =
       if original_height == 0 do
@@ -217,4 +227,8 @@ defmodule BackBreeze.Style do
       _, t_style -> t_style
     end)
   end
+
+  defp maybe_append_row(rows, ""), do: rows
+  defp maybe_append_row(rows, nil), do: rows
+  defp maybe_append_row(rows, row), do: rows ++ [String.trim_trailing(row, "\n")]
 end

--- a/test/back_breeze/box_test.exs
+++ b/test/back_breeze/box_test.exs
@@ -175,6 +175,74 @@ defmodule BackBreeze.BoxTest do
                """
     end
 
+    test "renders absolute children from a fixed-height child as a parent overlay" do
+      dropdown =
+        BackBreeze.Box.new(
+          style: %{width: 6, height: 1},
+          children: [
+            BackBreeze.Box.new(content: "POST"),
+            BackBreeze.Box.new(content: "GET\nPUT", position: :absolute, left: 0, top: 1)
+          ]
+        )
+
+      sibling = BackBreeze.Box.new(content: "URL")
+
+      box =
+        BackBreeze.Box.new(
+          style: %{border: :line},
+          children: [dropdown, sibling]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      assert rendered.content ==
+               """
+               ┌──────┐
+               │POST  │
+               │GET   │
+               │PUT   │
+               │URL   │
+               └──────┘\
+               """
+    end
+
+    test "absolute full-size children fill their parent" do
+      overlay =
+        BackBreeze.Box.new(
+          position: :absolute,
+          top: 0,
+          left: 0,
+          style: %{width: :full, height: :full, background_color: 0}
+        )
+
+      label =
+        BackBreeze.Box.new(
+          content: "Help",
+          position: :absolute,
+          top: 1,
+          left: 2,
+          style: %{foreground_color: 7, background_color: 0}
+        )
+
+      box =
+        BackBreeze.Box.new(
+          style: %{border: :line, width: 8, height: 4},
+          children: [overlay, label]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      assert rendered.content ==
+               """
+               ┌────────┐
+               │\e[48;5;0m \e[0m\e[48;5;0;38;5;7mHelp\e[0m\e[48;5;0m   \e[0m│
+               │\e[48;5;0m        \e[0m│
+               │\e[48;5;0m        \e[0m│
+               │\e[48;5;0m        \e[0m│
+               └────────┘\
+               """
+    end
+
     test "clips children with width-screen overflow hidden" do
       child = BackBreeze.Box.new(content: "ABCDEFGHIJKLMNOPQRST")
 

--- a/test/back_breeze/grid_test.exs
+++ b/test/back_breeze/grid_test.exs
@@ -36,7 +36,7 @@ defmodule BackBreeze.GridTest do
     items = ["Foo", "Bar", "Baz"] |> Enum.map(&BackBreeze.Box.new(content: &1))
     style = %BackBreeze.Style{width: :screen, height: :screen} |> BackBreeze.Style.border()
 
-    assert {"Foo   Bar   Baz   \n                  \n                  ", 18, 3} =
+    assert {"Foo   Bar   Baz   \n                  ", 18, 2} =
              BackBreeze.Grid.render(items, %Grid{columns: 3}, style, terminal: terminal)
   end
 end

--- a/test/back_breeze/style_test.exs
+++ b/test/back_breeze/style_test.exs
@@ -67,6 +67,38 @@ defmodule BackBreeze.StyleTest do
       assert length(output) == height
       assert String.length(hd(output)) == width
     end
+
+    test "renders unbordered screen-sized content without losing two rows" do
+      style =
+        BackBreeze.Style.height(:screen)
+        |> BackBreeze.Style.width(:screen)
+
+      {output, dimensions} =
+        BackBreeze.Style.calculate_and_render(
+          style,
+          "x",
+          terminal: %Termite.Terminal{size: %{width: 10, height: 4}}
+        )
+
+      assert dimensions.height == 4
+      assert output |> String.split("\n") |> hd() |> String.length() == 10
+    end
+
+    test "renders padding rows with background styling" do
+      style =
+        BackBreeze.Style.height(3)
+        |> BackBreeze.Style.width(4)
+        |> BackBreeze.Style.background_color(0)
+
+      output = BackBreeze.Style.render(style, "")
+
+      assert output ==
+               """
+               \e[48;5;0m    \e[0m
+               \e[48;5;0m    \e[0m
+               \e[48;5;0m    \e[0m\
+               """
+    end
   end
 
   describe "overflow/2" do

--- a/test/integration/grid_test.exs
+++ b/test/integration/grid_test.exs
@@ -85,6 +85,57 @@ defmodule BackBreeze.Integration.GridTest do
     assert heights == [3, 3, 3]
   end
 
+  test "grid fits explicit row heights back into the available height" do
+    child = fn label, height ->
+      BackBreeze.Box.new(style: %{border: :line, height: height}, content: label)
+    end
+
+    box =
+      BackBreeze.Box.new(
+        children: [child.("Top", 9), child.("Bottom", 7)],
+        style: %{border: :line, width: :screen, height: 21},
+        display: %BackBreeze.Grid{columns: 1, rows: 2}
+      )
+
+    %{dimensions: dimensions} =
+      BackBreeze.Box.render_with_dimensions(box,
+        terminal: %Termite.Terminal{size: %{width: 40, height: 24}}
+      )
+
+    heights = dimensions |> Enum.drop(1) |> Enum.map(& &1.height)
+    assert heights == [11, 9]
+  end
+
+  test "grid assigns height to bordered children with absolute overlays" do
+    panel =
+      BackBreeze.Box.new(
+        style: %{border: :rounded},
+        children: [
+          BackBreeze.Box.new(content: "Body", style: %{height: :full}),
+          BackBreeze.Box.new(position: :absolute, left: 2, top: 0, content: "Title")
+        ]
+      )
+
+    box =
+      BackBreeze.Box.new(
+        children: [panel],
+        style: %{width: 20, height: 6},
+        display: %BackBreeze.Grid{columns: 1, rows: 1}
+      )
+
+    rendered = BackBreeze.Box.render(box)
+
+    assert rendered.content ==
+             """
+             ╭─Title────────────╮
+             │Body              │
+             │                  │
+             │                  │
+             │                  │
+             ╰──────────────────╯\
+             """
+  end
+
   test "grid dimensions" do
     %{dimensions: dimensions} =
       BackBreeze.Box.render_with_dimensions(grid_box(),


### PR DESCRIPTION
The sizing calculations were previously incorrectly assuming all elements had a border. Absolutely positioned elements were also not working as intended when nested inside of a grid.