### PR TITLE
feat(BackBreeze.Box): change the sizing model to border-box

### DIFF
--- a/examples/scrollbar.exs
+++ b/examples/scrollbar.exs
@@ -9,9 +9,10 @@ vertical_content =
     "Row #{row}: Lorem ipsum"
   end)
 
-vertical_height = 5
+vertical_viewport_height = 5
+vertical_height = vertical_viewport_height + 2
 vertical_line_count = vertical_content |> String.split("\n") |> length()
-max_vertical_scroll = max(vertical_line_count - vertical_height, 0)
+max_vertical_scroll = max(vertical_line_count - vertical_viewport_height, 0)
 
 vertical_top =
   BackBreeze.Box.new(
@@ -19,7 +20,8 @@ vertical_top =
     scroll: {0, 0},
     style: %{
       border: :line,
-      width: 20,
+      border_color: 3,
+      width: 22,
       height: vertical_height,
       overflow: :hidden,
       scrollbar: true
@@ -32,11 +34,11 @@ vertical_bottom =
     scroll: {max_vertical_scroll, 0},
     style: %{
       border: :line,
-      border_color: 3,
-      width: 20,
+      border_color: 4,
+      width: 22,
       height: vertical_height,
       overflow: :hidden,
-      scrollbar: true
+      scrollbar: %{thumb: %{foreground_color: 2}, track: %{foreground_color: 8}}
     }
   )
 
@@ -46,10 +48,15 @@ horizontal =
     scroll: {0, 10},
     style: %{
       border: :line,
-      width: 18,
-      height: 2,
+      border_color: 5,
+      width: 20,
+      height: 4,
       overflow: :hidden,
-      scrollbar: %{axis: :horizontal}
+      scrollbar: %{
+        axis: :horizontal,
+        thumb: %{foreground_color: 6},
+        track: %{foreground_color: 8}
+      }
     }
   )
 
@@ -63,8 +70,8 @@ both_axes =
     style: %{
       border: :line,
       border_color: 3,
-      width: 18,
-      height: 4,
+      width: 20,
+      height: 6,
       overflow: :hidden,
       scrollbar: %{
         axis: :both,
@@ -77,9 +84,9 @@ both_axes =
 
 height_full =
   BackBreeze.Box.new(
-    style: %{border: :line, width: 24, height: 6, overflow: :hidden},
+    style: %{border: :line, border_color: 6, width: 26, height: 8, overflow: :hidden},
     children: [
-      BackBreeze.Box.new(content: "Fixed header"),
+      BackBreeze.Box.new(content: "Fixed header", style: %{foreground_color: 6}),
       BackBreeze.Box.new(
         content:
           Enum.map_join(1..12, "\n", fn row ->
@@ -89,7 +96,7 @@ height_full =
           width: :full,
           height: :full,
           overflow: :hidden,
-          scrollbar: true
+          scrollbar: %{thumb: %{foreground_color: 2}, track: %{foreground_color: 8}}
         }
       )
     ]

--- a/lib/back_breeze/box.ex
+++ b/lib/back_breeze/box.ex
@@ -287,212 +287,225 @@ defmodule BackBreeze.Box do
       end)
 
     structured? = Keyword.get(opts, :structured, false)
+    children_content_height = content_height(children, box.display)
 
-    if not structured? and plain_content_container?(box, child_layer_map, has_overlay_children?) do
-      render_plain_content_container(
-        acc,
-        prev_id,
-        child_layer_map,
-        child_width,
-        child_height,
-        child_layer,
-        opts
-      )
-    else
-      style_width = if box.style.width == :auto, do: 0, else: box.style.width
+    cond do
+      not structured? and
+        is_binary(child_layer_map) and box.scroll == {0, 0} and
+        box.style.scrollbar == false and not has_overlay_children? and
+        plain_wrapper_style?(box) and
+        box.style.width not in [:full, :screen] and
+          box.style.height not in [:full, :screen] ->
+        render_wrapped_content_container(
+          acc,
+          prev_id,
+          box,
+          child_layer_map,
+          child_layer,
+          opts
+        )
 
-      width =
-        cond do
-          box.style.overflow == :hidden ->
-            box.style.width
+      not structured? and plain_content_container?(box, child_layer_map, has_overlay_children?) ->
+        render_plain_content_container(
+          acc,
+          prev_id,
+          child_layer_map,
+          child_width,
+          child_height,
+          child_layer,
+          opts
+        )
 
-          is_integer(box.style.width) and box.style.width > 0 ->
-            box.style.width
+      true ->
+        style_width = if box.style.width == :auto, do: 0, else: box.style.width
 
-          true ->
-            max(style_width, child_width)
-        end
+        width =
+          cond do
+            box.style.overflow == :hidden ->
+              box.style.width
 
-      style_height = if box.style.height == :auto, do: 0, else: box.style.height
+            is_integer(box.style.width) and box.style.width > 0 ->
+              box.style.width
 
-      height =
-        cond do
-          box.style.overflow == :hidden ->
-            box.style.height
+            true ->
+              max(
+                style_width,
+                child_width + padding_horizontal(box.style) + border_horizontal(box.style.border)
+              )
+          end
 
-          is_integer(box.style.height) and box.style.height > 0 ->
-            box.style.height
+        style_height = if box.style.height == :auto, do: 0, else: box.style.height
 
-          true ->
-            max(
-              style_height,
-              child_height +
-                padding_vertical(box.style) +
-                if(padding_vertical(box.style) > 0, do: 1, else: 0)
-            )
-        end
+        height =
+          cond do
+            box.style.overflow == :hidden ->
+              box.style.height
 
-      style = %{box.style | width: width, height: height}
+            is_integer(box.style.height) and box.style.height > 0 ->
+              box.style.height
 
-      # We don't want offset to apply twice in cases when there are children.
-      {content, dimensions, _width} =
-        BenchProfile.measure({__MODULE__, :render_self}, fn ->
-          render_self(%{box | width: width, height: height, style: style, scroll: {0, 0}}, opts)
-        end)
+            true ->
+              max(
+                style_height,
+                children_content_height +
+                  padding_vertical(box.style) +
+                  border_vertical(box.style.border)
+              )
+          end
 
-      border_rows =
-        if(box.style.border.top, do: 1, else: 0) +
-          if box.style.border.bottom, do: 1, else: 0
+        style = %{box.style | width: width, height: height}
 
-      dimensions = %{
-        content_height: content_height(children, box.display),
-        viewport_height: dimensions.height - border_rows,
-        viewport_width: width,
-        height: dimensions.height,
-        width: width
-      }
-
-      dimensions =
-        if box.style.height in [:auto, :full] ||
-             (is_integer(box.style.height) && box.style.height <= 0 && box.style.width != :screen) do
-          resolved_height = max(dimensions.height, dimensions.content_height)
-
-          %{
-            dimensions
-            | height: resolved_height,
-              viewport_height: max(dimensions.viewport_height, resolved_height - border_rows)
-          }
-        else
-          dimensions
-        end
-
-      dimensions =
-        dimensions
-        |> Map.put(:width, width)
-        |> Map.put_new(:viewport_width, width)
-        |> Map.put_new(:content_width, width)
-        |> Map.put(:left, 0)
-        |> Map.put(:top, 0)
-
-      acc = %{acc | dimensions: [{prev_id, dimensions} | acc.dimensions], id: acc.id}
-
-      rendered_width = raw_content_width(content)
-
-      {layer_map, max_width, max_height} =
-        BenchProfile.measure({__MODULE__, :container_base_layer}, fn ->
-          cached_blank_container_layer_map(box, rendered_width, dimensions.height) ||
-            cached_generate_layer_map(content)
-        end)
-
-      max_height = max(max_height, max(rendered_height(content) - 1, 0))
-
-      {offset_top, offset_left} = box.scroll
-
-      child_layer_map =
-        if offset_left > 0 do
-          shift_layer_map(child_layer_map, -offset_left, 0)
-        else
-          child_layer_map
-        end
-
-      clip_relative_children? =
-        box.style.overflow == :hidden ||
-          (is_integer(box.style.height) && box.style.height > 0 && !has_overlay_children?)
-
-      child_layer_map =
-        if clip_relative_children? and
-             (offset_left > 0 or
-                offset_top > 0 or
-                clip_child_layer_map_required?(
-                  child_width,
-                  child_height,
-                  box.style,
-                  max_width,
-                  max_height,
-                  has_overlay_children?
-                )) do
-          BenchProfile.measure({__MODULE__, :clip_child_layer_map}, fn ->
-            clip_child_layer_map(child_layer_map, box.style, max_width, max_height)
+        # We don't want offset to apply twice in cases when there are children.
+        {content, dimensions, _width} =
+          BenchProfile.measure({__MODULE__, :render_self}, fn ->
+            render_self(%{box | width: width, height: height, style: style, scroll: {0, 0}}, opts)
           end)
-        else
-          child_layer_map
-        end
 
-      max_width =
-        if box.style.overflow == :hidden do
-          max_width
-        else
-          max(max_width, child_width)
-        end
+        border_rows =
+          if(box.style.border.top, do: 1, else: 0) +
+            if box.style.border.bottom, do: 1, else: 0
 
-      max_height =
-        cond do
-          box.style.overflow == :hidden ->
-            max_height
+        dimensions = %{
+          content_height: children_content_height,
+          viewport_height: dimensions.height - border_rows,
+          viewport_width: width,
+          height: dimensions.height,
+          width: width
+        }
 
-          box.style.height in [:auto, :full] ||
-              (is_integer(box.style.height) && box.style.height <= 0) ->
-            max(max_height, child_height)
+        dimensions =
+          if box.style.height in [:auto, :full] ||
+               (is_integer(box.style.height) && box.style.height <= 0 &&
+                  box.style.width != :screen) do
+            resolved_height = max(dimensions.height, dimensions.content_height)
 
-          has_overlay_children? ->
-            max(max_height, child_height)
+            %{
+              dimensions
+              | height: resolved_height,
+                viewport_height: max(dimensions.viewport_height, resolved_height - border_rows)
+            }
+          else
+            dimensions
+          end
 
-          true ->
-            max_height
-        end
+        dimensions =
+          dimensions
+          |> Map.put(:width, width)
+          |> Map.put_new(:viewport_width, width)
+          |> Map.put_new(:content_width, width)
+          |> Map.put(:left, 0)
+          |> Map.put(:top, 0)
 
-      child_layer_map =
-        BenchProfile.measure({__MODULE__, :scrollbar_layer_map}, fn ->
-          BackBreeze.Scrollbar.add_to_layer_map(child_layer_map, %{
-            style: box.style,
-            scroll: box.scroll,
-            content_height: dimensions.content_height,
-            content_width: child_width,
-            max_x: max_width,
-            max_y: max_height
-          })
-        end)
+        acc = %{acc | dimensions: [{prev_id, dimensions} | acc.dimensions], id: acc.id}
 
-      {child_offset_left, child_offset_top} = padding_origin(box.style)
+        rendered_width = raw_content_width(content)
 
-      child_layer_map =
-        if child_offset_left > 0 or child_offset_top > 0 do
-          shift_layer_map(child_layer_map, child_offset_left, child_offset_top)
-        else
-          child_layer_map
-        end
+        {layer_map, max_width, max_height} =
+          BenchProfile.measure({__MODULE__, :container_base_layer}, fn ->
+            cached_blank_container_layer_map(box, rendered_width, dimensions.height) ||
+              cached_generate_layer_map(content)
+          end)
 
-      merged_layer_map =
-        BenchProfile.measure({__MODULE__, :merge_layer_maps}, fn ->
-          Map.merge(layer_map, child_layer_map)
-        end)
+        max_height = max(max_height, max(rendered_height(content) - 1, 0))
 
-      content =
-        if structured? do
-          nil
-        else
-          BenchProfile.measure({__MODULE__, :layer_maps_to_content}, fn ->
-            cached_layer_maps_to_content(layer_map, child_layer_map, %{
-              start_x: 0,
-              start_y: 0,
+        {offset_top, offset_left} = box.scroll
+
+        child_layer_map =
+          if offset_left > 0 do
+            shift_layer_map(child_layer_map, -offset_left, 0)
+          else
+            child_layer_map
+          end
+
+        clip_relative_children? =
+          box.style.overflow == :hidden ||
+            (is_integer(box.style.height) && box.style.height > 0 && !has_overlay_children?)
+
+        child_layer_map =
+          if clip_relative_children? and
+               (offset_left > 0 or
+                  offset_top > 0 or
+                  clip_child_layer_map_required?(
+                    child_width,
+                    child_height,
+                    box.style,
+                    max_width,
+                    max_height,
+                    has_overlay_children?
+                  )) do
+            BenchProfile.measure({__MODULE__, :clip_child_layer_map}, fn ->
+              clip_child_layer_map(child_layer_map, box.style, max_width, max_height)
+            end)
+          else
+            child_layer_map
+          end
+
+        max_width =
+          if box.style.overflow == :hidden do
+            max_width
+          else
+            max(max_width, child_width)
+          end
+
+        max_height =
+          cond do
+            box.style.overflow == :hidden ->
+              max_height
+
+            box.style.height in [:auto, :full] ||
+                (is_integer(box.style.height) && box.style.height <= 0) ->
+              max(max_height, child_height)
+
+            has_overlay_children? ->
+              max(max_height, child_height)
+
+            true ->
+              max_height
+          end
+
+        child_layer_map =
+          BenchProfile.measure({__MODULE__, :scrollbar_layer_map}, fn ->
+            BackBreeze.Scrollbar.add_to_layer_map(child_layer_map, %{
+              style: box.style,
+              scroll: box.scroll,
+              content_height: dimensions.content_height,
+              content_width: child_width,
               max_x: max_width,
               max_y: max_height
             })
           end)
-        end
 
-      box = %{
-        box
-        | content: content,
-          width: max_width + 1,
-          height: max_height + 1,
-          layer: max(box.layer || 0, child_layer || 0),
-          state: :rendered,
-          layer_map: merged_layer_map,
-          overlay?: has_overlay_children?
-      }
+        merged_layer_map =
+          BenchProfile.measure({__MODULE__, :merge_layer_maps}, fn ->
+            Map.merge(layer_map, child_layer_map)
+          end)
 
-      %{acc | box: box}
+        content =
+          if structured? do
+            nil
+          else
+            BenchProfile.measure({__MODULE__, :layer_maps_to_content}, fn ->
+              cached_layer_maps_to_content(layer_map, child_layer_map, %{
+                start_x: 0,
+                start_y: 0,
+                max_x: max_width,
+                max_y: max_height
+              })
+            end)
+          end
+
+        box = %{
+          box
+          | content: content,
+            width: max_width + 1,
+            height: max_height + 1,
+            layer: max(box.layer || 0, child_layer || 0),
+            state: :rendered,
+            layer_map: merged_layer_map,
+            overlay?: has_overlay_children?
+        }
+
+        %{acc | box: box}
     end
   end
 
@@ -534,10 +547,37 @@ defmodule BackBreeze.Box do
     %{acc | box: box, dimensions: [{prev_id, dimensions} | acc.dimensions], id: acc.id}
   end
 
+  defp render_wrapped_content_container(
+         %{box: box} = acc,
+         prev_id,
+         box,
+         child_content,
+         child_layer,
+         opts
+       ) do
+    {content, dimensions, width} =
+      render_self(%{box | content: child_content, children: [], scroll: {0, 0}}, opts)
+
+    box = %{
+      box
+      | content: content,
+        width: width,
+        height: dimensions.height,
+        layer: max(box.layer || 0, child_layer || 0),
+        state: :rendered,
+        children: [],
+        layer_map: %{},
+        overlay?: false
+    }
+
+    %{acc | box: box, dimensions: [{prev_id, dimensions} | acc.dimensions], id: acc.id}
+  end
+
   defp render_self(box, opts) do
     {offset_top, _} = box.scroll
     opts = Keyword.put(opts, :offset_top, offset_top)
     terminal = Keyword.get(opts, :terminal)
+    box = normalize_render_self_box(box)
 
     cache_key =
       {:render_self, box.style, box.content, offset_top,
@@ -548,6 +588,25 @@ defmodule BackBreeze.Box do
       max_width = raw_content_width(content)
       {content, dimensions, max_width}
     end)
+  end
+
+  defp normalize_render_self_box(box) do
+    style =
+      box.style
+      |> maybe_resolve_render_self_extent(:width, box.width)
+      |> maybe_resolve_render_self_extent(:height, box.height)
+
+    %{box | style: style}
+  end
+
+  defp maybe_resolve_render_self_extent(style, _field, value) when not is_integer(value),
+    do: style
+
+  defp maybe_resolve_render_self_extent(style, field, value) do
+    case Map.get(style, field) do
+      extent when extent in [:full, :screen] -> Map.put(style, field, value)
+      _ -> style
+    end
   end
 
   defp render_children(
@@ -683,6 +742,13 @@ defmodule BackBreeze.Box do
           {id + length(grouped), Enum.reverse(entries, acc_d)}
       end)
       |> then(fn {final_id, dims} -> {final_id, Enum.reverse(dims)} end)
+
+    {content_left, content_top} = content_origin(box.style)
+
+    new_dims =
+      Enum.map(new_dims, fn {id, dims} ->
+        {id, shift_dimension(dims, content_left, content_top)}
+      end)
 
     acc = %{acc | dimensions: acc.dimensions ++ new_dims, id: final_id}
 
@@ -890,8 +956,7 @@ defmodule BackBreeze.Box do
   end
 
   defp do_combine_children(box, [], relative, _opts) do
-    border = box.style.border
-    {start_x, start_y} = container_origin(border)
+    {start_x, start_y} = content_origin(box.style)
 
     if layer_map_entries?(relative.layer_map) do
       merge_layer_map(%{}, relative.layer_map, start_x, start_y)
@@ -902,7 +967,7 @@ defmodule BackBreeze.Box do
 
   defp do_combine_children(box, [absolute], relative, opts) do
     border = box.style.border
-    {rel_x, rel_y} = container_origin(border)
+    {rel_x, rel_y} = content_origin(box.style)
     {overlay_x, overlay_y} = resolve_overlay_origin(absolute, box, relative, border, opts)
 
     {base_map, base_width, base_height} =
@@ -995,14 +1060,6 @@ defmodule BackBreeze.Box do
     }
   end
 
-  defp container_origin(border) do
-    case {border.left, border.top} do
-      {nil, nil} -> {0, 0}
-      {_, nil} -> {1, 0}
-      _ -> {1, 1}
-    end
-  end
-
   defp merge_rendered_box(layer_map, rendered_box, box, relative, border, opts) do
     merge_rendered_box(layer_map, rendered_box, box, relative, border, opts, 0, 0)
   end
@@ -1023,7 +1080,7 @@ defmodule BackBreeze.Box do
           resolve_overlay_origin(rendered_box, box, relative, border, opts)
 
         _ ->
-          container_origin(border)
+          content_origin(box.style)
       end
 
     {map, width, height} =
@@ -1110,6 +1167,7 @@ defmodule BackBreeze.Box do
       style.border
       |> Map.put(:color, style.border_color || style.border.color)
       |> Map.put(:background_color, style.background_color)
+
     border_seq = border_style_sequence(border)
     fill_seq = content_style_sequence(style)
     map = %{}
@@ -1747,10 +1805,15 @@ defmodule BackBreeze.Box do
     )
   end
 
+  defp resolved_parent_width(%{width: rendered_width, style: style}, _opts)
+       when is_integer(rendered_width) do
+    max(rendered_width - border_horizontal(style.border) - padding_horizontal(style), 0)
+  end
+
   defp resolved_parent_width(%{style: %{width: width} = style}, opts) do
     case width do
       w when is_integer(w) ->
-        max(w - padding_horizontal(style), 0)
+        max(w - border_horizontal(style.border) - padding_horizontal(style), 0)
 
       :screen ->
         {screen_width, _screen_height} =
@@ -1763,10 +1826,15 @@ defmodule BackBreeze.Box do
     end
   end
 
+  defp resolved_parent_height(%{height: rendered_height, style: style}, _opts)
+       when is_integer(rendered_height) do
+    max(rendered_height - border_vertical(style.border) - padding_vertical(style), 0)
+  end
+
   defp resolved_parent_height(%{style: %{height: height} = style}, opts) do
     case height do
       h when is_integer(h) ->
-        max(h - padding_vertical(style), 0)
+        max(h - border_vertical(style.border) - padding_vertical(style), 0)
 
       :screen ->
         {_screen_width, screen_height} =
@@ -1803,13 +1871,11 @@ defmodule BackBreeze.Box do
           plain_wrap_leaf_child?(child)
 
       should_fill_width? =
-        (display != :inline && child.style.width == :full) || auto_wrap_leaf_child? ||
+        (display != :inline && child.style.width in [:full, :screen]) || auto_wrap_leaf_child? ||
           (not overlay_position?(child) && auto_fill_container?)
 
       if should_fill_width? do
-        border_adj = border_horizontal(child.style.border)
-
-        %{child | style: %{child.style | width: max(0, parent_width - border_adj)}}
+        %{child | style: %{child.style | width: max(0, parent_width)}}
       else
         child
       end
@@ -1819,9 +1885,8 @@ defmodule BackBreeze.Box do
   defp resolve_fill_width(child, _display, nil, _used_width, _overflow), do: child
 
   defp resolve_fill_width(child, :inline, parent_width, used_width, _overflow) do
-    if child.style.width == :full and not overlay_position?(child) do
-      border_adj = border_horizontal(child.style.border)
-      remaining_width = max(parent_width - used_width - border_adj, 0)
+    if child.style.width in [:full, :screen] and not overlay_position?(child) do
+      remaining_width = max(parent_width - used_width, 0)
       %{child | style: %{child.style | width: remaining_width}}
     else
       child
@@ -1833,23 +1898,19 @@ defmodule BackBreeze.Box do
   defp resolve_fill_height(child, _display, nil, _used_height), do: child
 
   defp resolve_fill_height(child, :inline, parent_height, _used_height) do
-    if child.style.height == :full do
-      border_adj = border_vertical(child.style.border)
-
-      %{child | style: %{child.style | height: max(0, parent_height - border_adj)}}
+    if child.style.height in [:full, :screen] do
+      %{child | style: %{child.style | height: max(0, parent_height)}}
     else
       child
     end
   end
 
   defp resolve_fill_height(child, :block, parent_height, used_height) do
-    if child.style.height != :full do
+    if child.style.height not in [:full, :screen] do
       child
     else
-      border_adj = border_vertical(child.style.border)
-
       used_height = if overlay_position?(child), do: 0, else: used_height
-      %{child | style: %{child.style | height: max(0, parent_height - used_height - border_adj)}}
+      %{child | style: %{child.style | height: max(0, parent_height - used_height)}}
     end
   end
 
@@ -1886,10 +1947,16 @@ defmodule BackBreeze.Box do
 
   defp resolve_overlay_fill_size(child, _parent, _opts), do: child
 
-  defp constrained_overlay_extent(extent, start_edge, end_edge, container_extent, border_extent)
+  defp constrained_overlay_extent(extent, start_edge, end_edge, container_extent, _border_extent)
        when extent in [:screen, :full] and is_integer(start_edge) and is_integer(end_edge) and
               is_integer(container_extent) do
-    max(container_extent - start_edge - end_edge - border_extent, 0)
+    max(container_extent - start_edge - end_edge, 0)
+  end
+
+  defp constrained_overlay_extent(extent, start_edge, end_edge, container_extent, _border_extent)
+       when is_integer(extent) and is_integer(start_edge) and is_integer(end_edge) and
+              is_integer(container_extent) and extent >= container_extent do
+    max(container_extent - start_edge - end_edge, 0)
   end
 
   defp constrained_overlay_extent(
@@ -2054,9 +2121,6 @@ defmodule BackBreeze.Box do
   defp padding_vertical(style),
     do: style_value(style, :padding_top) + style_value(style, :padding_bottom)
 
-  defp padding_origin(style),
-    do: {style_value(style, :padding_left), style_value(style, :padding_top)}
-
   defp content_origin(style) do
     {
       border_left_offset(style.border) + style_value(style, :padding_left),
@@ -2065,7 +2129,10 @@ defmodule BackBreeze.Box do
   end
 
   defp style_value(style, side_key) do
-    Map.get(style, side_key, Map.get(style, :padding, 0))
+    case Map.get(style, side_key) do
+      value when is_integer(value) -> value
+      _ -> Map.get(style, :padding, 0) || 0
+    end
   end
 
   defp plain_content_container?(box, child_content, has_overlay_children?)
@@ -2073,7 +2140,7 @@ defmodule BackBreeze.Box do
     box.scroll == {0, 0} and
       box.children != [] and
       box.style.scrollbar == false and
-      not has_overlay_children?
+      not has_overlay_children? and plain_wrapper_style?(box)
   end
 
   defp plain_content_container?(_box, _child_layer_map, _has_overlay_children?), do: false
@@ -2092,10 +2159,10 @@ defmodule BackBreeze.Box do
            bold: false,
            italic: false,
            padding: 0,
-           padding_top: 0,
-           padding_right: 0,
-           padding_bottom: 0,
-           padding_left: 0,
+           padding_top: nil,
+           padding_right: nil,
+           padding_bottom: nil,
+           padding_left: nil,
            reverse: false,
            border: border,
            overflow: :auto,
@@ -2171,14 +2238,14 @@ defmodule BackBreeze.Box do
       first_size(
         rendered_parent && rendered_parent.width,
         parent.width,
-        parent.style.width
+        resolved_parent_overlay_extent(parent, :width, border, opts)
       )
 
     height =
       first_size(
         rendered_parent && rendered_parent.height,
         parent.height,
-        parent.style.height
+        resolved_parent_overlay_extent(parent, :height, border, opts)
       )
 
     {
@@ -2187,8 +2254,8 @@ defmodule BackBreeze.Box do
     }
   end
 
-  defp resolved_overlay_width(width, border, _opts) when is_integer(width),
-    do: width + border_horizontal(border)
+  defp resolved_overlay_width(width, _border, _opts) when is_integer(width),
+    do: width
 
   defp resolved_overlay_width(:screen, _border, opts) do
     {screen_width, _screen_height} = BackBreeze.screen_dimensions(Keyword.get(opts, :terminal))
@@ -2197,8 +2264,8 @@ defmodule BackBreeze.Box do
 
   defp resolved_overlay_width(_, _border, _opts), do: 0
 
-  defp resolved_overlay_height(height, border, _opts) when is_integer(height),
-    do: height + border_vertical(border)
+  defp resolved_overlay_height(height, _border, _opts) when is_integer(height),
+    do: height
 
   defp resolved_overlay_height(:screen, _border, opts) do
     {_screen_width, screen_height} = BackBreeze.screen_dimensions(Keyword.get(opts, :terminal))
@@ -2206,6 +2273,36 @@ defmodule BackBreeze.Box do
   end
 
   defp resolved_overlay_height(_, _border, _opts), do: 0
+
+  defp resolved_parent_overlay_extent(%{position: :fixed} = parent, :width, _border, opts) do
+    {screen_width, _screen_height} = BackBreeze.screen_dimensions(Keyword.get(opts, :terminal))
+
+    constrained_overlay_extent(
+      parent.style.width,
+      parent.left,
+      parent.right,
+      screen_width,
+      border_horizontal(parent.style.border)
+    ) || resolved_overlay_width(parent.style.width, parent.style.border, opts)
+  end
+
+  defp resolved_parent_overlay_extent(%{position: :fixed} = parent, :height, _border, opts) do
+    {_screen_width, screen_height} = BackBreeze.screen_dimensions(Keyword.get(opts, :terminal))
+
+    constrained_overlay_extent(
+      parent.style.height,
+      parent.top,
+      parent.bottom,
+      screen_height,
+      border_vertical(parent.style.border)
+    ) || resolved_overlay_height(parent.style.height, parent.style.border, opts)
+  end
+
+  defp resolved_parent_overlay_extent(parent, :width, _border, opts),
+    do: Map.get(parent.style, :width) |> resolved_overlay_width(parent.style.border, opts)
+
+  defp resolved_parent_overlay_extent(parent, :height, _border, opts),
+    do: Map.get(parent.style, :height) |> resolved_overlay_height(parent.style.border, opts)
 
   defp resolve_edge_offset(value, _opposite, _child_size, _container_size) when is_integer(value),
     do: value

--- a/lib/back_breeze/grid.ex
+++ b/lib/back_breeze/grid.ex
@@ -27,7 +27,11 @@ defmodule BackBreeze.Grid do
         other -> other
       end
 
-    width_offset = if(style.border.left, do: 1, else: 0) + if style.border.right, do: 1, else: 0
+    width_offset =
+      if(style.border.left, do: 1, else: 0) +
+        if(style.border.right, do: 1, else: 0) +
+        style_value(style, :padding_left) +
+        style_value(style, :padding_right)
 
     height =
       case style.height do
@@ -35,7 +39,11 @@ defmodule BackBreeze.Grid do
         other -> other
       end
 
-    height_offset = if(style.border.top, do: 1, else: 0) + if style.border.bottom, do: 1, else: 0
+    height_offset =
+      if(style.border.top, do: 1, else: 0) +
+        if(style.border.bottom, do: 1, else: 0) +
+        style_value(style, :padding_top) +
+        style_value(style, :padding_bottom)
 
     rows = Enum.chunk_every(items, grid.columns)
     row_count = grid.rows || length(rows)
@@ -71,12 +79,20 @@ defmodule BackBreeze.Grid do
   defp render_with_dimensions(items, grid, style, opts, structured?) do
     {screen_width, screen_height} = BackBreeze.screen_dimensions(Keyword.get(opts, :terminal))
 
-    width_offset = if(style.border.left, do: 1, else: 0) + if style.border.right, do: 1, else: 0
+    width_offset =
+      if(style.border.left, do: 1, else: 0) +
+        if(style.border.right, do: 1, else: 0) +
+        style_value(style, :padding_left) +
+        style_value(style, :padding_right)
 
     # Although this is similar to the calculation in precompute, dividing into columns happens
     # only if the width is not explicitly specified, compared to always dividing in the
     # precompute function
-    height_offset = if(style.border.top, do: 1, else: 0) + if style.border.bottom, do: 1, else: 0
+    height_offset =
+      if(style.border.top, do: 1, else: 0) +
+        if(style.border.bottom, do: 1, else: 0) +
+        style_value(style, :padding_top) +
+        style_value(style, :padding_bottom)
 
     rows = Enum.chunk_every(items, grid.columns)
     row_count = grid.rows || length(rows)
@@ -84,12 +100,13 @@ defmodule BackBreeze.Grid do
     total_width =
       case style.width do
         width when width in @auto_sizes -> screen_width - width_offset
+        other when is_integer(other) -> max(other - width_offset, 0)
         other -> other
       end
 
     total_height =
       case style.height do
-        h when is_integer(h) and h > 0 -> h
+        h when is_integer(h) and h > 0 -> max(h - height_offset, 0)
         _ -> screen_height - height_offset
       end
 
@@ -113,14 +130,10 @@ defmodule BackBreeze.Grid do
 
           cols
           |> Enum.with_index()
-          |> Enum.map(fn {%{style: %{border: border}} = item, col_index} ->
+          |> Enum.map(fn {item, col_index} ->
             col_width = Enum.at(column_widths, col_index, 0)
-
-            width =
-              col_width - if(border.left, do: 1, else: 0) - if(border.right, do: 1, else: 0)
-
-            height =
-              row_height - if(border.top, do: 1, else: 0) - if(border.bottom, do: 1, else: 0)
+            width = col_width
+            height = row_height
 
             style = %{item.style | width: max(width, 0), height: max(height, 0)}
 
@@ -263,7 +276,7 @@ defmodule BackBreeze.Grid do
 
   defp resolved_extent(value, total, rendered) do
     cond do
-      is_integer(value) and value > 0 -> total
+      is_integer(value) and value > 0 -> value
       value in @auto_sizes -> total
       true -> rendered || total
     end
@@ -309,10 +322,9 @@ defmodule BackBreeze.Grid do
     case item do
       %{style: style} ->
         style_value = Map.get(style, axis)
-        border_size = border_size(style.border, axis)
 
         case style_value do
-          value when is_integer(value) and value > 0 -> value + border_size
+          value when is_integer(value) and value > 0 -> value
           _ -> nil
         end
 
@@ -320,12 +332,6 @@ defmodule BackBreeze.Grid do
         nil
     end
   end
-
-  defp border_size(border, :width),
-    do: if(border.left, do: 1, else: 0) + if(border.right, do: 1, else: 0)
-
-  defp border_size(border, :height),
-    do: if(border.top, do: 1, else: 0) + if(border.bottom, do: 1, else: 0)
 
   defp distribute_dimension(count, total, explicit, grow_indexes) do
     explicit_total =
@@ -418,5 +424,12 @@ defmodule BackBreeze.Grid do
 
   defp materialized_content(%{layer_map: layer_map, width: width, height: height}) do
     BackBreeze.Box.layer_map_to_content(layer_map, width, height)
+  end
+
+  defp style_value(style, side_key) do
+    case Map.get(style, side_key) do
+      value when is_integer(value) -> value
+      _ -> Map.get(style, :padding, 0) || 0
+    end
   end
 end

--- a/lib/back_breeze/scrollbar.ex
+++ b/lib/back_breeze/scrollbar.ex
@@ -234,7 +234,8 @@ defmodule BackBreeze.Scrollbar do
     %{
       config
       | vertical: Map.new(config.vertical, fn {k, s} -> {k, background_segment(s, color)} end),
-        horizontal: Map.new(config.horizontal, fn {k, s} -> {k, background_segment(s, color)} end),
+        horizontal:
+          Map.new(config.horizontal, fn {k, s} -> {k, background_segment(s, color)} end),
         intersection: background_segment(config.intersection, color)
     }
   end
@@ -763,7 +764,8 @@ defmodule BackBreeze.Scrollbar do
     %{thumb: thumb, track: track, arrow_start: arrow_start, arrow_end: arrow_end}
   end
 
-  defp merge_segment(%Segment{} = segment, map, fallback_color, fallback_background) when is_map(map) do
+  defp merge_segment(%Segment{} = segment, map, fallback_color, fallback_background)
+       when is_map(map) do
     char = Map.get(map, :char, segment.char)
 
     segment =

--- a/lib/back_breeze/style.ex
+++ b/lib/back_breeze/style.ex
@@ -7,10 +7,10 @@ defmodule BackBreeze.Style do
   defstruct bold: false,
             italic: false,
             padding: 0,
-            padding_top: 0,
-            padding_right: 0,
-            padding_bottom: 0,
-            padding_left: 0,
+            padding_top: nil,
+            padding_right: nil,
+            padding_bottom: nil,
+            padding_left: nil,
             reverse: false,
             border: BackBreeze.Border.none(),
             text_align: :left,
@@ -167,26 +167,57 @@ defmodule BackBreeze.Style do
     style = Map.from_struct(style)
 
     string_length = BackBreeze.Utils.string_length(str)
+    source_lines = String.split(str, "\n")
+
+    intrinsic_width =
+      Enum.reduce(source_lines, 0, fn line, acc ->
+        max(acc, BackBreeze.Utils.string_length(line))
+      end)
 
     {border, style} = Map.pop(style, :border)
     {text_align, style} = Map.pop(style, :text_align, :left)
     {overflow, style} = Map.pop(style, :overflow)
     {padding, style} = Map.pop(style, :padding, 0)
-    {padding_top, style} = Map.pop(style, :padding_top, padding)
-    {padding_right, style} = Map.pop(style, :padding_right, padding)
-    {padding_bottom, style} = Map.pop(style, :padding_bottom, padding)
-    {padding_left, style} = Map.pop(style, :padding_left, padding)
-    {width, style} = Map.pop(style, :width, string_length)
-    {height, style} = Map.pop(style, :height, 0)
+    {padding_top, style} = Map.pop(style, :padding_top, nil)
+    {padding_right, style} = Map.pop(style, :padding_right, nil)
+    {padding_bottom, style} = Map.pop(style, :padding_bottom, nil)
+    {padding_left, style} = Map.pop(style, :padding_left, nil)
+    padding_top = if(is_integer(padding_top), do: padding_top, else: padding)
+    padding_right = if(is_integer(padding_right), do: padding_right, else: padding)
+    padding_bottom = if(is_integer(padding_bottom), do: padding_bottom, else: padding)
+    padding_left = if(is_integer(padding_left), do: padding_left, else: padding)
+    {width, style} = Map.pop(style, :width, :auto)
+    {height, style} = Map.pop(style, :height, :auto)
 
-    auto_width = width in [:auto, :full]
+    auto_width = width == :auto
     border_width = if(border.left, do: 1, else: 0) + if(border.right, do: 1, else: 0)
     border_height = if(border.top, do: 1, else: 0) + if(border.bottom, do: 1, else: 0)
 
-    width = if width in [:auto, :full], do: string_length, else: width
-    width = if width == :screen, do: screen_width - border_width, else: width
-    height = if height == :full, do: 0, else: height
-    height = if height == :screen, do: screen_height - border_height, else: height
+    width =
+      cond do
+        width == :auto -> intrinsic_width
+        width in [:screen, :full] -> screen_width
+        true -> width
+      end
+
+    width =
+      if is_integer(width) and not auto_width,
+        do: max(width - border_width - padding_left - padding_right, 0),
+        else: width
+
+    auto_height = height == :auto
+
+    height =
+      cond do
+        height == :auto -> 0
+        height in [:screen, :full] -> screen_height
+        true -> height
+      end
+
+    height =
+      if is_integer(height) and not auto_height,
+        do: max(height - border_height - padding_top - padding_bottom, 0),
+        else: height
 
     str =
       cond do
@@ -212,8 +243,9 @@ defmodule BackBreeze.Style do
     original_height = height
 
     width =
-      if auto_width && length(lines) > 1,
-        do: BackBreeze.Utils.string_length(hd(lines)),
+      if auto_width,
+        do:
+          Enum.reduce(lines, 0, fn line, acc -> max(acc, BackBreeze.Utils.string_length(line)) end),
         else: width
 
     start_pos = Keyword.get(opts, :offset_top, 0)
@@ -243,7 +275,7 @@ defmodule BackBreeze.Style do
 
     bottom_padding_rows = blank_rows(padding_bottom, border, termite_style, inner_width)
 
-    line_count = padding_top + length(lines) + padding_bottom
+    line_count = length(lines)
 
     padding_rows =
       case height - line_count do

--- a/test/back_breeze/box_test.exs
+++ b/test/back_breeze/box_test.exs
@@ -4,7 +4,10 @@ defmodule BackBreeze.BoxTest do
   describe "render_with_dimensions/2" do
     test "calculates nested dimensions" do
       child = BackBreeze.Box.new(content: "Hello\nWorld", style: %{border: :line})
-      inner_box = BackBreeze.Box.new(children: [child, child], style: %{border: :line, height: 6})
+
+      inner_box =
+        BackBreeze.Box.new(children: [child, child], style: %{border: :line, height: 10})
+
       box = BackBreeze.Box.new(children: [inner_box])
       %{box: box, dimensions: dimensions} = BackBreeze.Box.render_with_dimensions(box)
 
@@ -17,49 +20,46 @@ defmodule BackBreeze.BoxTest do
                │└─────┘│
                │┌─────┐│
                ││Hello││
+               ││World││
+               │└─────┘│
                └───────┘\
                """
 
       assert dimensions == [
                %{
+                 height: 10,
+                 content_height: 10,
+                 viewport_height: 10
+               },
+               %{
                  left: 0,
                  top: 0,
                  width: 9,
-                 height: 8,
+                 height: 10,
                  content_width: 9,
                  content_height: 8,
                  viewport_height: 8,
                  viewport_width: 9
                },
                %{
-                 left: 0,
-                 top: 0,
-                 width: 7,
-                 height: 8,
-                 content_width: 7,
-                 content_height: 8,
-                 viewport_height: 6,
-                 viewport_width: 7
-               },
-               %{
                  left: 1,
                  top: 1,
                  width: 7,
-                 viewport_width: 7,
-                 content_width: 7,
                  height: 4,
+                 content_width: 7,
                  content_height: 2,
-                 viewport_height: 2
+                 viewport_height: 2,
+                 viewport_width: 7
                },
                %{
                  left: 1,
                  top: 5,
                  width: 7,
-                 viewport_width: 7,
-                 content_width: 7,
                  height: 4,
+                 content_width: 7,
                  content_height: 2,
-                 viewport_height: 2
+                 viewport_height: 2,
+                 viewport_width: 7
                }
              ]
     end
@@ -159,7 +159,7 @@ defmodule BackBreeze.BoxTest do
     test "parent background fills unused interior rows around child content" do
       box =
         BackBreeze.Box.new(
-          style: %{border: :line, background_color: 0, width: 8, height: 4},
+          style: %{border: :line, background_color: 0, width: 10, height: 6},
           children: [BackBreeze.Box.new(content: "Hello", style: %{foreground_color: 7})]
         )
 
@@ -236,7 +236,6 @@ defmodule BackBreeze.BoxTest do
       assert rendered.content ==
                """
                ┌\e[1;38;5;3mHello\e[0m┐
-               │     │
                └─────┘\
                """
     end
@@ -246,7 +245,7 @@ defmodule BackBreeze.BoxTest do
 
       box =
         BackBreeze.Box.new(
-          style: %{border: :line, width: 6, height: 1, overflow: :hidden},
+          style: %{border: :line, width: 8, height: 3, overflow: :hidden},
           children: [child]
         )
 
@@ -266,7 +265,7 @@ defmodule BackBreeze.BoxTest do
       box =
         BackBreeze.Box.new(
           scroll: {0, 2},
-          style: %{border: :line, width: 6, height: 1, overflow: :hidden},
+          style: %{border: :line, width: 8, height: 3, overflow: :hidden},
           children: [child]
         )
 
@@ -284,7 +283,7 @@ defmodule BackBreeze.BoxTest do
       box =
         BackBreeze.Box.new(
           scroll: {1, 2},
-          style: %{border: :line, width: 6, height: 2, overflow: :hidden},
+          style: %{border: :line, width: 8, height: 4, overflow: :hidden},
           children: [
             BackBreeze.Box.new(content: "AAAAAA"),
             BackBreeze.Box.new(content: "BBBBBB"),
@@ -307,7 +306,7 @@ defmodule BackBreeze.BoxTest do
       box =
         BackBreeze.Box.new(
           scroll: {1, 0},
-          style: %{border: :line, width: 6, height: 2, overflow: :hidden},
+          style: %{border: :line, width: 8, height: 4, overflow: :hidden},
           children: [
             BackBreeze.Box.new(content: "AAAAAA"),
             BackBreeze.Box.new(content: "BBBBBB"),
@@ -331,7 +330,7 @@ defmodule BackBreeze.BoxTest do
 
       box =
         BackBreeze.Box.new(
-          style: %{border: :line, width: 6, height: 1, overflow: :hidden},
+          style: %{border: :line, width: 8, height: 3, overflow: :hidden},
           children: [child]
         )
 
@@ -396,7 +395,7 @@ defmodule BackBreeze.BoxTest do
 
       box =
         BackBreeze.Box.new(
-          style: %{border: :line, width: 8, height: 4},
+          style: %{border: :line, width: 10, height: 6},
           children: [overlay, label]
         )
 
@@ -418,7 +417,7 @@ defmodule BackBreeze.BoxTest do
 
       box =
         BackBreeze.Box.new(
-          style: %{border: :line, width: 8, height: 4},
+          style: %{border: :line, width: 10, height: 6},
           children: [child]
         )
 
@@ -460,7 +459,7 @@ defmodule BackBreeze.BoxTest do
 
       box =
         BackBreeze.Box.new(
-          style: %{border: :line, width: 8, height: 4},
+          style: %{border: :line, width: 10, height: 6},
           children: [child]
         )
 
@@ -529,12 +528,41 @@ defmodule BackBreeze.BoxTest do
                """
     end
 
+    test "reports inset-constrained fixed screen overlay dimensions from the constrained outer size" do
+      child =
+        BackBreeze.Box.new(
+          position: :fixed,
+          left: 1,
+          right: 1,
+          top: 1,
+          bottom: 1,
+          style: %{border: :line, width: :screen, height: :screen}
+        )
+
+      box =
+        BackBreeze.Box.new(
+          style: %{width: :screen, height: :screen},
+          children: [child]
+        )
+
+      %{dimensions: dimensions} =
+        BackBreeze.Box.render_with_dimensions(
+          box,
+          terminal: %Termite.Terminal{size: %{width: 10, height: 6}}
+        )
+
+      assert Enum.any?(dimensions, fn
+               %{left: 1, top: 1, width: 8, height: 4} -> true
+               _ -> false
+             end)
+    end
+
     test "clips children with width-screen overflow hidden" do
       child = BackBreeze.Box.new(content: "ABCDEFGHIJKLMNOPQRST")
 
       box =
         BackBreeze.Box.new(
-          style: %{border: :line, width: :screen, height: 1, overflow: :hidden},
+          style: %{border: :line, width: :screen, height: 3, overflow: :hidden},
           children: [child]
         )
 
@@ -560,7 +588,7 @@ defmodule BackBreeze.BoxTest do
 
       box =
         BackBreeze.Box.new(
-          style: %{border: :line, width: 6, height: 5, overflow: :hidden},
+          style: %{border: :line, width: 8, height: 7, overflow: :hidden},
           children: [header, body]
         )
 
@@ -583,7 +611,7 @@ defmodule BackBreeze.BoxTest do
 
       box =
         BackBreeze.Box.new(
-          style: %{border: :line, width: 6, height: 3, overflow: :hidden, scrollbar: true},
+          style: %{border: :line, width: 8, height: 5, overflow: :hidden, scrollbar: true},
           children: [child]
         )
 
@@ -605,7 +633,7 @@ defmodule BackBreeze.BoxTest do
       box =
         BackBreeze.Box.new(
           scroll: {3, 0},
-          style: %{border: :line, width: 6, height: 3, overflow: :hidden, scrollbar: true},
+          style: %{border: :line, width: 8, height: 5, overflow: :hidden, scrollbar: true},
           children: [child]
         )
 
@@ -626,7 +654,7 @@ defmodule BackBreeze.BoxTest do
         BackBreeze.Box.new(
           content: "AAAAAA\nBBBBBB\nCCCCCC\nDDDDDD\nEEEEEE\nFFFFFF",
           scroll: {1, 0},
-          style: %{border: :line, width: 6, height: 3, overflow: :hidden, scrollbar: true}
+          style: %{border: :line, width: 8, height: 5, overflow: :hidden, scrollbar: true}
         )
 
       rendered = BackBreeze.Box.render(box)
@@ -648,8 +676,8 @@ defmodule BackBreeze.BoxTest do
         BackBreeze.Box.new(
           style: %{
             border: :line,
-            width: 6,
-            height: 3,
+            width: 8,
+            height: 5,
             overflow: :hidden,
             scrollbar: %{
               axis: :vertical,
@@ -673,8 +701,8 @@ defmodule BackBreeze.BoxTest do
         BackBreeze.Box.new(
           style: %{
             border: :line,
-            width: 6,
-            height: 3,
+            width: 8,
+            height: 5,
             overflow: :hidden,
             scrollbar: %{axis: :vertical, placement: :start}
           },
@@ -700,8 +728,8 @@ defmodule BackBreeze.BoxTest do
         BackBreeze.Box.new(
           style: %{
             border: :line,
-            width: 5,
-            height: 2,
+            width: 7,
+            height: 4,
             overflow: :hidden,
             scrollbar: %{axis: :horizontal}
           },
@@ -724,7 +752,7 @@ defmodule BackBreeze.BoxTest do
 
       box =
         BackBreeze.Box.new(
-          style: %{border: :line, width: 6, height: 3, overflow: :hidden, scrollbar: true},
+          style: %{border: :line, width: 8, height: 5, overflow: :hidden, scrollbar: true},
           children: [child]
         )
 
@@ -741,8 +769,8 @@ defmodule BackBreeze.BoxTest do
         BackBreeze.Box.new(
           style: %{
             border: :line,
-            width: 6,
-            height: 3,
+            width: 8,
+            height: 5,
             overflow: :hidden,
             scrollbar: %{axis: :vertical, sizing: {:fixed, 1}}
           },
@@ -808,8 +836,8 @@ defmodule BackBreeze.BoxTest do
         BackBreeze.Box.new(
           style: %{
             border: :line,
-            width: 6,
-            height: 1,
+            width: 8,
+            height: 3,
             overflow: :hidden,
             scrollbar: %{axis: :vertical, show: :always}
           },
@@ -833,7 +861,7 @@ defmodule BackBreeze.BoxTest do
         BackBreeze.Box.new(
           content: content,
           scroll: {26, 0},
-          style: %{border: :line, width: 6, height: 4, overflow: :hidden, scrollbar: true}
+          style: %{border: :line, width: 8, height: 6, overflow: :hidden, scrollbar: true}
         )
 
       rendered = BackBreeze.Box.render(box)
@@ -857,8 +885,8 @@ defmodule BackBreeze.BoxTest do
           scroll: {1, 3},
           style: %{
             border: :line,
-            width: 6,
-            height: 4,
+            width: 8,
+            height: 6,
             overflow: :hidden,
             scrollbar: %{axis: :both, arrows: true}
           },
@@ -881,8 +909,8 @@ defmodule BackBreeze.BoxTest do
         BackBreeze.Box.new(
           style: %{
             border: :line,
-            width: 6,
-            height: 4,
+            width: 8,
+            height: 6,
             overflow: :hidden,
             scrollbar: %{axis: :both, arrows: true}
           },
@@ -903,8 +931,8 @@ defmodule BackBreeze.BoxTest do
         BackBreeze.Box.new(
           style: %{
             border: :line,
-            width: 6,
-            height: 4,
+            width: 8,
+            height: 6,
             overflow: :hidden,
             scrollbar: %{axis: :both, arrows: true}
           },
@@ -924,8 +952,8 @@ defmodule BackBreeze.BoxTest do
         BackBreeze.Box.new(
           style: %{
             border: :line,
-            width: 5,
-            height: 2,
+            width: 7,
+            height: 4,
             overflow: :hidden,
             scrollbar: %{
               axis: :horizontal,
@@ -949,7 +977,7 @@ defmodule BackBreeze.BoxTest do
       box =
         BackBreeze.Box.new(
           scroll: {2, 0},
-          style: %{border: :line, width: 1, height: 7, overflow: :hidden, scrollbar: true},
+          style: %{border: :line, width: 3, height: 9, overflow: :hidden, scrollbar: true},
           children: [absolute_child | relative_children]
         )
 
@@ -977,8 +1005,8 @@ defmodule BackBreeze.BoxTest do
           scroll: {1, 3},
           style: %{
             border: :line,
-            width: 6,
-            height: 4,
+            width: 8,
+            height: 6,
             overflow: :hidden,
             scrollbar: %{axis: :both, arrows: %{foreground_color: 2}}
           },
@@ -1022,8 +1050,8 @@ defmodule BackBreeze.BoxTest do
             border: :line,
             border_color: 3,
             background_color: 0,
-            width: 8,
-            height: 3,
+            width: 10,
+            height: 5,
             overflow: :hidden,
             scrollbar: %{axis: :vertical, arrows: true}
           },
@@ -1042,8 +1070,8 @@ defmodule BackBreeze.BoxTest do
           style: %{
             border: :line,
             border_color: 3,
-            width: 8,
-            height: 3,
+            width: 10,
+            height: 5,
             overflow: :hidden,
             scrollbar: %{axis: :vertical, arrows: true}
           },
@@ -1087,15 +1115,15 @@ defmodule BackBreeze.BoxTest do
       box = BackBreeze.Box.new(children: [child], style: %{border: :line, width: 10})
       rendered = BackBreeze.Box.render(box)
 
-      # width: 10 is content width, so outer box is 12 wide (10 + 2 border)
-      # child fills to 10 content - 2 (child border) = 8 content, 10 total
+      # width: 10 is total outer width, so parent content width is 8
+      # child width-full fills that 8-wide content area, yielding 6 inner columns once bordered
       assert rendered.content ==
                """
-               ┌──────────┐
-               │┌────────┐│
-               ││Hi      ││
-               │└────────┘│
-               └──────────┘\
+               ┌────────┐
+               │┌──────┐│
+               ││Hi    ││
+               │└──────┘│
+               └────────┘\
                """
     end
 
@@ -1110,14 +1138,13 @@ defmodule BackBreeze.BoxTest do
 
       rendered = BackBreeze.Box.render(box)
 
-      # width: 8 is content width, outer box is 10 wide (8 + 2 border)
-      # children fill to parent_width = 8 (no child border to subtract)
+      # width: 8 is total outer width, so parent content width is 6
       assert rendered.content ==
                """
-               ┌────────┐
-               │A       │
-               │B       │
-               └────────┘\
+               ┌──────┐
+               │A     │
+               │B     │
+               └──────┘\
                """
     end
   end
@@ -1160,6 +1187,20 @@ defmodule BackBreeze.BoxTest do
                         Two   +  
                One lineLinesLines\
                """
+    end
+  end
+
+  describe "padding with children" do
+    test "insets child content once inside directional padding" do
+      box =
+        BackBreeze.Box.new(
+          style: %{width: 10, height: 4, padding_top: 1, padding_left: 1},
+          children: [BackBreeze.Box.new(content: "X")]
+        )
+
+      rendered = BackBreeze.Box.render(box)
+
+      assert rendered.content == "          \n X        \n          \n          "
     end
   end
 end

--- a/test/back_breeze/grid_test.exs
+++ b/test/back_breeze/grid_test.exs
@@ -38,5 +38,22 @@ defmodule BackBreeze.GridTest do
 
     assert {"Foo   Bar   Baz   \n                  ", 18, 2} =
              BackBreeze.Grid.render(items, %Grid{columns: 3}, style, terminal: terminal)
+
+    test "explicit grid size respects the grid's own horizontal padding" do
+      items = [
+        BackBreeze.Box.new(content: "HEADER"),
+        BackBreeze.Box.new(content: "FOOT")
+      ]
+
+      style =
+        %BackBreeze.Style{width: 20, height: 4}
+        |> BackBreeze.Style.padding_left(2)
+        |> BackBreeze.Style.padding_right(2)
+
+      assert {"HEADER          \n                \nFOOT            \n                ", 20, 4} =
+               BackBreeze.Grid.render(items, %Grid{columns: 1}, style,
+                 terminal: %Termite.Terminal{size: %{width: 20, height: 4}}
+               )
+    end
   end
 end

--- a/test/back_breeze/style_test.exs
+++ b/test/back_breeze/style_test.exs
@@ -5,12 +5,12 @@ defmodule BackBreeze.StyleTest do
     test "styles can be composed" do
       style =
         BackBreeze.Style.bold()
-        |> BackBreeze.Style.width(15)
+        |> BackBreeze.Style.width(17)
         |> BackBreeze.Style.border()
         |> BackBreeze.Style.foreground_color(3)
 
       assert style.bold
-      assert style.width == 15
+      assert style.width == 17
       assert style.border == BackBreeze.Border.line()
       assert style.foreground_color == 3
     end
@@ -36,7 +36,7 @@ defmodule BackBreeze.StyleTest do
     test "outputting the styles" do
       style =
         BackBreeze.Style.bold()
-        |> BackBreeze.Style.width(15)
+        |> BackBreeze.Style.width(17)
         |> BackBreeze.Style.border()
         |> BackBreeze.Style.foreground_color(3)
 
@@ -46,7 +46,7 @@ defmodule BackBreeze.StyleTest do
 
     test "renders borders with the box background color" do
       style =
-        BackBreeze.Style.width(5)
+        BackBreeze.Style.width(7)
         |> BackBreeze.Style.border()
         |> BackBreeze.Style.border_color(3)
         |> BackBreeze.Style.background_color(0)
@@ -63,7 +63,7 @@ defmodule BackBreeze.StyleTest do
 
     test "renders empty lines when a height is specified" do
       style =
-        BackBreeze.Style.height(3)
+        BackBreeze.Style.height(5)
         |> BackBreeze.Style.border()
 
       output = BackBreeze.Style.render(style, "Hello World")
@@ -149,13 +149,25 @@ defmodule BackBreeze.StyleTest do
 
     test "adds directional horizontal padding" do
       style =
-        BackBreeze.Style.width(3)
+        BackBreeze.Style.width(6)
         |> BackBreeze.Style.padding_left(1)
         |> BackBreeze.Style.padding_right(2)
 
       output = BackBreeze.Style.render(style, "Hey")
 
       assert output == " Hey  "
+    end
+
+    test "treats explicit height as outer height when padding is present" do
+      style =
+        BackBreeze.Style.height(4)
+        |> BackBreeze.Style.width(10)
+        |> BackBreeze.Style.padding_top(1)
+        |> BackBreeze.Style.padding_bottom(1)
+
+      output = BackBreeze.Style.render(style, "X")
+
+      assert output == "          \nX         \n          \n          "
     end
   end
 
@@ -213,7 +225,7 @@ defmodule BackBreeze.StyleTest do
 
       style =
         BackBreeze.Style.border()
-        |> BackBreeze.Style.width(30)
+        |> BackBreeze.Style.width(32)
 
       output = BackBreeze.Style.render(style, content)
 
@@ -233,8 +245,8 @@ defmodule BackBreeze.StyleTest do
 
       style =
         BackBreeze.Style.border()
-        |> BackBreeze.Style.width(30)
-        |> BackBreeze.Style.height(2)
+        |> BackBreeze.Style.width(32)
+        |> BackBreeze.Style.height(4)
         |> BackBreeze.Style.overflow(:hidden)
 
       output = BackBreeze.Style.render(style, content)
@@ -253,8 +265,8 @@ defmodule BackBreeze.StyleTest do
 
       style =
         BackBreeze.Style.border()
-        |> BackBreeze.Style.width(30)
-        |> BackBreeze.Style.height(8)
+        |> BackBreeze.Style.width(32)
+        |> BackBreeze.Style.height(10)
 
       output = BackBreeze.Style.render(style, content)
 
@@ -278,7 +290,7 @@ defmodule BackBreeze.StyleTest do
 
       style =
         BackBreeze.Style.border()
-        |> BackBreeze.Style.width(10)
+        |> BackBreeze.Style.width(12)
         |> BackBreeze.Style.overflow(:hidden)
 
       output = BackBreeze.Style.render(style, content)
@@ -291,8 +303,8 @@ defmodule BackBreeze.StyleTest do
 
       style =
         BackBreeze.Style.border()
-        |> BackBreeze.Style.width(7)
-        |> BackBreeze.Style.height(3)
+        |> BackBreeze.Style.width(9)
+        |> BackBreeze.Style.height(5)
         |> BackBreeze.Style.overflow(:hidden)
 
       output = BackBreeze.Style.render(style, content, offset_top: 1)

--- a/test/integration/absolute_test.exs
+++ b/test/integration/absolute_test.exs
@@ -28,7 +28,7 @@ defmodule BackBreeze.AbsoluteTest do
 
     box =
       BackBreeze.Box.new(%{
-        style: %{border: :line, width: size.width * 2, height: size.height},
+        style: %{border: :line, width: size.width * 2 + 2, height: size.height + 2},
         children: [a, b, c, title]
       })
       |> BackBreeze.Box.render()
@@ -41,9 +41,9 @@ defmodule BackBreeze.AbsoluteTest do
              │                              │
              │             ┌─\e[38;5;2mccccc\e[0m          │
              │             │aaaa│           │
-             │             │    │           │
-             │             │    │           │
              │             └────┘           │
+             │                              │
+             │                              │
              │                              │
              │                              │
              └──────────────────────────────┘\

--- a/test/integration/grid_cache_test.exs
+++ b/test/integration/grid_cache_test.exs
@@ -21,7 +21,7 @@ defmodule BackBreeze.Integration.GridCacheTest do
     box =
       Box.new(
         children: [child],
-        style: %{width: 10},
+        style: %{width: 10, height: 3},
         display: %Grid{columns: 1}
       )
 
@@ -33,16 +33,16 @@ defmodule BackBreeze.Integration.GridCacheTest do
 
     assert small.content ==
              """
-             ┌──────────┐
-             │X         │
-             └──────────┘\
+             ┌────────┐
+             │X       │
+             └────────┘\
              """
 
     assert large.content ==
              """
-             ┌──────────────┐
-             │X             │
-             └──────────────┘\
+             ┌────────┐
+             │X       │
+             └────────┘\
              """
   end
 end

--- a/test/integration/grid_test.exs
+++ b/test/integration/grid_test.exs
@@ -31,18 +31,18 @@ defmodule BackBreeze.Integration.GridTest do
     assert box.content ==
              """
              ┌───────────────────────────────────────────────────┐
-             │┌───────────────┐┌───────────────┐┌───────────────┐│
-             ││Left           ││Top            ││Right          ││
-             ││123            ││               ││               ││
-             ││456            │└───────────────┘│               ││
-             ││               │┌───────────────┐│               ││
-             ││               ││Middle         ││               ││
-             ││               ││123            ││               ││
-             ││               │└───────────────┘│               ││
-             ││               │┌───────────────┐│               ││
-             ││               ││Bottom         ││               ││
-             ││               ││               ││               ││
-             │└───────────────┘└───────────────┘└───────────────┘│
+             │┌───────────────┐┌─────────────┐┌───────────────┐  │
+             ││Left           ││Top          ││Right          │  │
+             ││123            ││             ││               │  │
+             ││456            │└─────────────┘│               │  │
+             ││               │┌─────────────┐│               │  │
+             ││               ││Middle       ││               │  │
+             ││               ││123          ││               │  │
+             ││               │└─────────────┘│               │  │
+             ││               │┌─────────────┐│               │  │
+             ││               ││Bottom       ││               │  │
+             ││               ││             ││               │  │
+             │└───────────────┘└─────────────┘└───────────────┘  │
              └───────────────────────────────────────────────────┘\
              """
   end
@@ -103,7 +103,7 @@ defmodule BackBreeze.Integration.GridTest do
       )
 
     heights = dimensions |> Enum.drop(1) |> Enum.map(& &1.height)
-    assert heights == [11, 9]
+    assert heights == [9, 7]
   end
 
   test "grid assigns height to bordered children with absolute overlays" do
@@ -154,8 +154,8 @@ defmodule BackBreeze.Integration.GridTest do
                viewport_width: :screen
              },
              %{
-               left: 0,
-               top: 0,
+               left: 1,
+               top: 1,
                width: 17,
                content_width: 17,
                height: 12,
@@ -164,8 +164,8 @@ defmodule BackBreeze.Integration.GridTest do
                viewport_width: 17
              },
              %{
-               left: 17,
-               top: 0,
+               left: 18,
+               top: 1,
                width: 17,
                content_width: 17,
                height: 12,
@@ -174,38 +174,38 @@ defmodule BackBreeze.Integration.GridTest do
                viewport_width: 17
              },
              %{
-               left: 17,
-               top: 0,
-               width: 17,
-               content_width: 17,
+               left: 18,
+               top: 1,
+               width: 15,
+               content_width: 15,
                height: 4,
                content_height: 1,
                viewport_height: 1,
-               viewport_width: 17
+               viewport_width: 15
              },
              %{
-               left: 17,
-               top: 4,
-               width: 17,
-               content_width: 17,
+               left: 18,
+               top: 5,
+               width: 15,
+               content_width: 15,
                height: 4,
                content_height: 2,
                viewport_height: 2,
-               viewport_width: 17
+               viewport_width: 15
              },
              %{
-               left: 17,
-               top: 8,
-               width: 17,
-               content_width: 17,
+               left: 18,
+               top: 9,
+               width: 15,
+               content_width: 15,
                height: 4,
                content_height: 1,
                viewport_height: 1,
-               viewport_width: 17
+               viewport_width: 15
              },
              %{
-               left: 34,
-               top: 0,
+               left: 35,
+               top: 1,
                width: 17,
                content_width: 17,
                height: 12,


### PR DESCRIPTION
When working with breeze, it became clear that the having the specified width be the rendered width is a lot easier to reason about. Previously, the borders were considered outside of the width, but padding was considered a part of the width. This mixed model was very difficult to understand in practical use.

All of the tests and examples have been updated to consider this new model.